### PR TITLE
Support half frame rated interlaced modes

### DIFF
--- a/Plugins/nosUtilities/Source/DeinterlacedBoundedTextureQueue.cpp
+++ b/Plugins/nosUtilities/Source/DeinterlacedBoundedTextureQueue.cpp
@@ -119,6 +119,12 @@ struct DeinterlacedBoundedTextureQueueNode : RingNodeBase
 		}
 		return res;
 	}
+
+	void OverrideConsumerDeltaSeconds(nosVec2u& inoutDeltaSeconds) override
+	{
+		if (ShouldInterlace)
+			inoutDeltaSeconds.y /= 2;
+	}
 };
 
 nosResult RegisterDeinterlacedBoundedTextureQueue(nosNodeFunctions* functions)

--- a/Plugins/nosUtilities/Source/DeinterlacedBufferRing.cpp
+++ b/Plugins/nosUtilities/Source/DeinterlacedBufferRing.cpp
@@ -104,6 +104,12 @@ struct DeinterlacedBufferRingNode : RingNodeBase
 			LastPopped = nullptr;
 		}
 	}
+
+	void OverrideConsumerDeltaSeconds(nosVec2u& inoutDeltaSeconds) override
+	{
+		if (ShouldDeinterlace)
+			inoutDeltaSeconds.y *= 2;
+	}
 };
 
 nosResult RegisterDeinterlacedBufferRing(nosNodeFunctions* functions)

--- a/Plugins/nosUtilities/Source/UtilitiesMain.cpp
+++ b/Plugins/nosUtilities/Source/UtilitiesMain.cpp
@@ -7,7 +7,7 @@
 
 #include <nosVulkanSubsystem/nosVulkanSubsystem.h>
 
-NOS_INIT_WITH_MIN_REQUIRED_MINOR(9)
+NOS_INIT_WITH_MIN_REQUIRED_MINOR(17)
 NOS_VULKAN_INIT()
 
 NOS_BEGIN_IMPORT_DEPS()


### PR DESCRIPTION
Adds support for half frame rated interlaced modes by overriding schedule information of most important pulling paths. Depends on https://github.com/mediaz/nodos/pull/835.

- [x] `DeinterlacedBufferRingNode`
- [x] `DeinterlacedTextureBoundedQueue`