### PR TITLE
Utilities: Fix cannot change pin value if sink path cannot run at given fps

### DIFF
--- a/Plugins/nosUtilities/Config/Sink.nosdef
+++ b/Plugins/nosUtilities/Config/Sink.nosdef
@@ -58,6 +58,15 @@
 						"can_show_as": "PROPERTY_ONLY",
 						"description": "Whether to schedule nodes at an unlimited or fixed rate",
 						"data": "Periodic"
+					},
+					{
+						"name": "DropAfterSeconds",
+						"display_name": "Drop After (Seconds)",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "If schedule requests are arriving faster than they can be processed, the node will restart the path after this many seconds",
+						"data": 1.0
 					}
 				]
 			}

--- a/Plugins/nosUtilities/Config/Sink.nosdef
+++ b/Plugins/nosUtilities/Config/Sink.nosdef
@@ -60,12 +60,12 @@
 						"data": "Periodic"
 					},
 					{
-						"name": "DropAfterSeconds",
-						"display_name": "Drop After (Seconds)",
+						"name": "LatencyBudget",
+						"display_name": "Latency Budget (Seconds)",
 						"type_name": "float",
 						"show_as": "PROPERTY",
 						"can_show_as": "INPUT_PIN_OR_PROPERTY",
-						"description": "If schedule requests are arriving faster than they can be processed, the node will restart the path after this many seconds",
+						"description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
 						"data": 1.0
 					}
 				]

--- a/Plugins/nosUtilities/Config/SinkGraph.nosdef
+++ b/Plugins/nosUtilities/Config/SinkGraph.nosdef
@@ -100,7 +100,7 @@
                 },
                 {
                     "id": "a9a32c7b-8907-4116-a252-c816d0be6c78",
-                    "name": "DropAfterSeconds",
+                    "name": "LatencyBudget",
                     "type_name": "float",
                     "show_as": "PROPERTY",
                     "can_show_as": "INPUT_PIN_OR_PROPERTY",
@@ -110,8 +110,8 @@
                     "def": 1.0,
                     "contents_type": "PortalPin",
                     "contents": { "source_id": "d9040ed3-7494-4fce-aa3d-82cfd31fadf8" },
-                    "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path after this many seconds",
-                    "display_name": "Drop After (Seconds)"
+                    "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
+                    "display_name": "Latency Budget (Seconds)"
                 }
             ],
             "pos": {
@@ -383,7 +383,7 @@
                             },
                             {
                                 "id": "d9040ed3-7494-4fce-aa3d-82cfd31fadf8",
-                                "name": "DropAfterSeconds",
+                                "name": "LatencyBudget",
                                 "type_name": "float",
                                 "show_as": "PROPERTY",
                                 "can_show_as": "INPUT_PIN_OR_PROPERTY",
@@ -396,8 +396,8 @@
                                 "def": 1.0,
                                 "contents_type": "JobPin",
                                 "contents": {},
-                                "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path after this many seconds",
-                                "display_name": "Drop After (Seconds)"
+                                "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
+                                "display_name": "Latency Budget (Seconds)"
                             }
                         ],
                         "pos": {

--- a/Plugins/nosUtilities/Config/SinkGraph.nosdef
+++ b/Plugins/nosUtilities/Config/SinkGraph.nosdef
@@ -1,387 +1,448 @@
-{
-	"nodes": [
-		{
-			"class_name": "SinkGraph",
-			"menu_info": {
-				"category": "Utilities",
-				"display_name": "Threaded Sink"
-			},
-			"node": {
-				"id": "962a7371-a9f4-44f0-8727-5fe5142fb2d8",
-				"name": "Sink",
-				"class_name": "nos.utilities.SinkGraph",
-				"pins": [
-					{
-						"id": "4c75ff3d-45a2-49fd-a48d-da6e9813bb98",
-						"name": "Sink Input",
-						"type_name": "nos.Generic",
-						"show_as": "INPUT_PIN",
-						"can_show_as": "INPUT_PIN_ONLY",
-						"pin_category": "",
-						"visualizer": {},
-						"data": {},
-						"referred_by": [],
-						"def": {},
-						"meta_data_map": [],
-						"contents_type": "PortalPin",
-						"contents": { "source_id": "b2e60afd-48ab-4f80-89dc-4c7c4323d326" },
-						"orphan_state": {},
-						"description": ""
-					},
-					{
-						"id": "44bbedd2-ea31-45c6-a979-bc6b6b16e678",
-						"name": "Sink FPS",
-						"display_name": "FPS",
-						"type_name": "float",
-						"show_as": "PROPERTY",
-						"can_show_as": "PROPERTY_ONLY",
-						"pin_category": "",
-						"visualizer": {},
-						"data": 60.0,
-						"referred_by": [],
-						"min": 0.01,
-						"max": 1000.0,
-						"def": 60.0,
-						"step": 9.9999,
-						"meta_data_map": [],
-						"contents_type": "PortalPin",
-						"contents": { "source_id": "b6712155-4b78-4220-81f9-4c23231ee688" },
-						"orphan_state": {},
-						"description": ""
-					},
-					{
-						"id": "8bdd8685-8d98-4feb-b10c-52e173c948d3",
-						"name": "AcceptsRepeat",
-						"display_name": "Accept Repeat",
-						"type_name": "bool",
-						"show_as": "PROPERTY",
-						"can_show_as": "PROPERTY_ONLY",
-						"pin_category": "",
-						"visualizer": {},
-						"data": false,
-						"referred_by": [],
-						"def": false,
-						"meta_data_map": [],
-						"contents_type": "PortalPin",
-						"contents": { "source_id": "48f150e3-ce1e-4143-9faf-a160d42f4fa2" },
-						"orphan_state": {},
-						"advanced_property": true
-					},
-					{
-						"id": "4100a156-de8c-4ede-81ff-58a76e11a147",
-						"name": "SinkMode",
-						"display_name": "Mode",
-						"type_name": "nos.utilities.SinkMode",
-						"show_as": "PROPERTY",
-						"can_show_as": "PROPERTY_ONLY",
-						"pin_category": "",
-						"visualizer": {},
-						"data": "Periodic",
-						"referred_by": [],
-						"def": "Periodic",
-						"meta_data_map": [],
-						"contents_type": "PortalPin",
-						"contents": { "source_id": "9ee5e170-ce7a-4b3d-b86a-3e3bf5a81aae" },
-						"orphan_state": {},
-						"description": "Whether to schedule nodes at an unlimited or fixed rate"
-					}
-				],
-				"pos": {
-					"x": 0.0,
-					"y": 0.0
-				},
-				"contents_type": "Graph",
-				"contents": {
-					"nodes": [
-						{
-							"id": "d1b0c5bd-7e81-44cc-b8dd-77a9e581b9a5",
-							"name": "Thread",
-							"class_name": "nos.Thread",
-							"always_execute": true,
-							"pins": [
-								{
-									"id": "09e6d1f5-8fd5-44c8-a41a-154487a46e99",
-									"name": "Run",
-									"type_name": "nos.exe",
-									"show_as": "OUTPUT_PIN",
-									"can_show_as": "OUTPUT_PIN_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": {},
-									"referred_by": [],
-									"def": {},
-									"meta_data_map": [],
-									"live": true,
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": ""
-								},
-								{
-									"id": "f87b680c-132f-4c7f-9a28-22eae1018fee",
-									"name": "Importance",
-									"type_name": "ulong",
-									"show_as": "PROPERTY",
-									"can_show_as": "PROPERTY_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": 0,
-									"referred_by": [],
-									"def": 0,
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": ""
-								}
-							],
-							"pos": {
-								"x": -738.0,
-								"y": 89.0
-							},
-							"contents_type": "Job",
-							"contents": { "type": "" },
-							"app_key": "",
-							"functions": [],
-							"function_category": "Default Node",
-							"status_messages": [],
-							"meta_data_map": [],
-							"orphan_state": {},
-							"description": "",
-							"template_parameters": []
-						},
-						{
-							"id": "54ebe1ba-e5b1-464a-9a44-2444894d1aff",
-							"name": "Sink",
-							"class_name": "nos.utilities.Sink",
-							"pins": [
-								{
-									"id": "47062421-7f2a-48a8-80b1-4720f49b6d14",
-									"name": "InExe",
-									"type_name": "nos.exe",
-									"show_as": "INPUT_PIN",
-									"can_show_as": "INPUT_PIN_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": {},
-									"referred_by": [],
-									"def": {},
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": ""
-								},
-								{
-									"id": "f762c472-cb25-4fb2-adcf-047cdd19d3b6",
-									"name": "Sink Input",
-									"type_name": "nos.Generic",
-									"show_as": "INPUT_PIN",
-									"can_show_as": "INPUT_PIN_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": {},
-									"referred_by": [],
-									"def": {},
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": "",
-									"display_name": "Output"
-								},
-								{
-									"id": "b6712155-4b78-4220-81f9-4c23231ee688",
-									"name": "Sink FPS",
-									"type_name": "float",
-									"show_as": "PROPERTY",
-									"can_show_as": "PROPERTY_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": 60.0,
-									"referred_by": [
-										"44bbedd2-ea31-45c6-a979-bc6b6b16e678"
-									],
-									"min": 0.01,
-									"max": 1000.0,
-									"def": 60.0,
-									"step": 9.9999,
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": ""
-								},
-								{
-									"id": "7a587325-e432-4be7-9461-9a15ae128b36",
-									"name": "Wait",
-									"type_name": "bool",
-									"show_as": "PROPERTY",
-									"can_show_as": "PROPERTY_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": true,
-									"referred_by": [
-									],
-									"def": true,
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": "Wait until gpu tasks(gpu nodes etc.) are completed."
-								},
-								{
-									"id": "48f150e3-ce1e-4143-9faf-a160d42f4fa2",
-									"name": "AcceptsRepeat",
-									"type_name": "bool",
-									"show_as": "PROPERTY",
-									"can_show_as": "PROPERTY_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": false,
-									"referred_by": [
-										"8bdd8685-8d98-4feb-b10c-52e173c948d3"
-									],
-									"def": false,
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": "Wait until GPU tasks are completed.",
-									"display_name": "Accepts Repeat"
-								},
-								{
-									"id": "9ee5e170-ce7a-4b3d-b86a-3e3bf5a81aae",
-									"name": "SinkMode",
-									"type_name": "nos.utilities.SinkMode",
-									"show_as": "PROPERTY",
-									"can_show_as": "PROPERTY_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": "Periodic",
-									"referred_by": [
-										"4100a156-de8c-4ede-81ff-58a76e11a147"
-									],
-									"def": "Periodic",
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": "Whether to schedule nodes at an unlimited or fixed rate",
-									"display_name": "Mode"
-								}
-							],
-							"pos": {
-								"x": -554.0,
-								"y": 128.0
-							},
-							"contents_type": "Job",
-							"contents": { "type": "" },
-							"app_key": "",
-							"functions": [],
-							"function_category": "Default Node",
-							"status_messages": [],
-							"meta_data_map": [
-								{
-									"key": "PluginVersion",
-									"value": "2.7.0"
-								}
-							],
-							"orphan_state": {},
-							"description": "",
-							"template_parameters": []
-						},
-						{
-							"id": "af033893-0867-4707-9560-d945c5fe7d5c",
-							"name": "Sink Input",
-							"class_name": "nos.internal.GraphInput",
-							"pins": [
-								{
-									"id": "0256925e-33d3-4d28-897f-64eabb6c23cb",
-									"name": "Output",
-									"type_name": "nos.Generic",
-									"show_as": "OUTPUT_PIN",
-									"can_show_as": "OUTPUT_PIN_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": {},
-									"referred_by": [],
-									"def": {},
-									"meta_data_map": [],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": ""
-								},
-								{
-									"id": "b2e60afd-48ab-4f80-89dc-4c7c4323d326",
-									"name": "Input",
-									"type_name": "nos.Generic",
-									"show_as": "INPUT_PIN",
-									"can_show_as": "INPUT_PIN_ONLY",
-									"pin_category": "",
-									"visualizer": {},
-									"data": {},
-									"referred_by": [
-										"4c75ff3d-45a2-49fd-a48d-da6e9813bb98"
-									],
-									"def": {},
-									"meta_data_map": [
-										{
-											"key": "PinHidden",
-											"value": "true"
-										}
-									],
-									"contents_type": "JobPin",
-									"contents": {},
-									"orphan_state": {},
-									"description": ""
-								}
-							],
-							"pos": {
-								"x": -938.0,
-								"y": 108.5
-							},
-							"contents_type": "Job",
-							"contents": { "type": "" },
-							"app_key": "",
-							"functions": [],
-							"function_category": "Default Node",
-							"status_messages": [],
-							"meta_data_map": [],
-							"orphan_state": {},
-							"description": "",
-							"template_parameters": []
-						}
-					],
-					"comments": [],
-					"connections": [
-						{
-							"from": "09e6d1f5-8fd5-44c8-a41a-154487a46e99",
-							"to": "47062421-7f2a-48a8-80b1-4720f49b6d14",
-							"id": "3419e78b-36a1-48b3-bca9-b4f9eafc44c5"
-						},
-						{
-							"from": "0256925e-33d3-4d28-897f-64eabb6c23cb",
-							"to": "f762c472-cb25-4fb2-adcf-047cdd19d3b6",
-							"id": "8608ea00-f581-4950-93f4-71023b49cf9a"
-						}
-					]
-				},
-				"app_key": "",
-				"functions": [],
-				"function_category": "Default Node",
-				"status_messages": [],
-				"meta_data_map": [
-					{
-						"key": "PluginVersion",
-						"value": "2.7.0"
-					}
-				],
-				"orphan_state": {},
-				"description": "",
-				"template_parameters": []
-			}
-		}
-	]
-}
+{ "nodes": [
+    {
+        "class_name": "SinkGraph",
+        "menu_info": {
+            "category": "Utilities",
+            "display_name": "Threaded Sink"
+        },
+        "node": {
+            "id": "9c4000ea-8fc7-4683-b257-2e16cea01b1a",
+            "name": "Sink",
+            "class_name": "nos.utilities.SinkGraph",
+            "pins": [
+                {
+                    "id": "aa8b2b61-086a-44f7-817f-90c75ef4da31",
+                    "name": "Sink Input",
+                    "type_name": "nos.Generic",
+                    "show_as": "INPUT_PIN",
+                    "can_show_as": "INPUT_PIN_ONLY",
+                    "visualizer": {
+                    },
+                    "data": {},
+                    "def": {},
+                    "meta_data_map": [
+                        {
+                            "key": "Category",
+                            "value": ""
+                        }
+                    ],
+                    "contents_type": "PortalPin",
+                    "contents": { "source_id": "47c5a6bf-30ec-45fb-8c18-5a3bf2432517" }
+                },
+                {
+                    "id": "c7791cb8-9ed8-48b9-832d-190f43d0539f",
+                    "name": "Sink FPS",
+                    "type_name": "float",
+                    "show_as": "PROPERTY",
+                    "can_show_as": "PROPERTY_ONLY",
+                    "visualizer": {
+                    },
+                    "data": 60.0,
+                    "min": 0.01,
+                    "max": 1000.0,
+                    "def": 60.0,
+                    "step": 9.9999,
+                    "meta_data_map": [
+                        {
+                            "key": "Category",
+                            "value": ""
+                        }
+                    ],
+                    "contents_type": "PortalPin",
+                    "contents": { "source_id": "2b5ae02f-1303-4b65-b0eb-3aa2db2b3151" },
+                    "display_name": "FPS"
+                },
+                {
+                    "id": "6f9bbb5d-1eb7-4ae7-b2c0-1e43b0ef4b69",
+                    "name": "AcceptsRepeat",
+                    "type_name": "bool",
+                    "show_as": "PROPERTY",
+                    "can_show_as": "PROPERTY_ONLY",
+                    "visualizer": {
+                    },
+                    "data": false,
+                    "def": false,
+                    "advanced_property": true,
+                    "meta_data_map": [
+                        {
+                            "key": "AdvancedProperty",
+                            "value": "true"
+                        },
+                        {
+                            "key": "Category",
+                            "value": ""
+                        }
+                    ],
+                    "contents_type": "PortalPin",
+                    "contents": { "source_id": "2e293aff-300d-4d6d-88e5-2c80324b9b23" },
+                    "display_name": "Accept Repeat"
+                },
+                {
+                    "id": "52607932-ccf6-48fc-ac69-bb769a97efda",
+                    "name": "SinkMode",
+                    "type_name": "nos.utilities.SinkMode",
+                    "show_as": "PROPERTY",
+                    "can_show_as": "PROPERTY_ONLY",
+                    "visualizer": {
+                    },
+                    "data": "Periodic",
+                    "def": "Periodic",
+                    "meta_data_map": [
+                        {
+                            "key": "Category",
+                            "value": ""
+                        }
+                    ],
+                    "contents_type": "PortalPin",
+                    "contents": { "source_id": "ecd236af-11e9-4c4b-a302-efc16d0eb2be" },
+                    "description": "Whether to schedule nodes at an unlimited or fixed rate",
+                    "display_name": "Mode"
+                },
+                {
+                    "id": "a9a32c7b-8907-4116-a252-c816d0be6c78",
+                    "name": "DropAfterSeconds",
+                    "type_name": "float",
+                    "show_as": "PROPERTY",
+                    "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                    "visualizer": {
+                    },
+                    "data": 1.0,
+                    "def": 1.0,
+                    "contents_type": "PortalPin",
+                    "contents": { "source_id": "d9040ed3-7494-4fce-aa3d-82cfd31fadf8" },
+                    "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path after this many seconds",
+                    "display_name": "Drop After (Seconds)"
+                }
+            ],
+            "pos": {
+                "x": 0.0,
+                "y": 0.0
+            },
+            "contents_type": "Graph",
+            "contents": {
+                "nodes": [
+                    {
+                        "id": "9d9691ff-b630-4117-ab66-0834166b368a",
+                        "name": "Thread",
+                        "class_name": "nos.Thread",
+                        "always_execute": true,
+                        "pins": [
+                            {
+                                "id": "692cc43f-b55a-4384-ba2f-73d2d4af2dbc",
+                                "name": "Run",
+                                "type_name": "nos.exe",
+                                "show_as": "OUTPUT_PIN",
+                                "can_show_as": "OUTPUT_PIN_ONLY",
+                                "visualizer": {
+                                },
+                                "data": {},
+                                "def": {},
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "live": true,
+                                "contents_type": "JobPin",
+                                "contents": {}
+                            },
+                            {
+                                "id": "df233737-c6df-4897-8ee4-ca1d7d93d127",
+                                "name": "Importance",
+                                "type_name": "ulong",
+                                "show_as": "PROPERTY",
+                                "can_show_as": "PROPERTY_ONLY",
+                                "visualizer": {
+                                },
+                                "data": 0,
+                                "def": 0,
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {}
+                            }
+                        ],
+                        "pos": {
+                            "x": -738.0,
+                            "y": 89.0
+                        },
+                        "contents_type": "Job",
+                        "contents": { "type": "" },
+                        "function_category": "Default Node",
+                        "plugin_version": {
+                            "major": 0,
+                            "minor": 0,
+                            "patch": 0
+                        }
+                    },
+                    {
+                        "id": "9a8d1b3a-4097-4985-bcf5-07f153b111dc",
+                        "name": "Sink Input",
+                        "class_name": "nos.internal.GraphInput",
+                        "pins": [
+                            {
+                                "id": "b7a036be-3e8c-4846-9b53-e5d0dd1bae74",
+                                "name": "Output",
+                                "type_name": "nos.Generic",
+                                "show_as": "OUTPUT_PIN",
+                                "can_show_as": "OUTPUT_PIN_ONLY",
+                                "visualizer": {
+                                },
+                                "data": {},
+                                "def": {},
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {}
+                            },
+                            {
+                                "id": "47c5a6bf-30ec-45fb-8c18-5a3bf2432517",
+                                "name": "Input",
+                                "type_name": "nos.Generic",
+                                "show_as": "INPUT_PIN",
+                                "can_show_as": "INPUT_PIN_ONLY",
+                                "visualizer": {
+                                },
+                                "data": {},
+                                "referred_by": [
+                                    "aa8b2b61-086a-44f7-817f-90c75ef4da31"
+                                ],
+                                "def": {},
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    },
+                                    {
+                                        "key": "PinHidden",
+                                        "value": "true"
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {}
+                            }
+                        ],
+                        "pos": {
+                            "x": -938.0,
+                            "y": 108.5
+                        },
+                        "contents_type": "Job",
+                        "contents": { "type": "" },
+                        "function_category": "Default Node",
+                        "plugin_version": {
+                            "major": 0,
+                            "minor": 0,
+                            "patch": 0
+                        }
+                    },
+                    {
+                        "id": "860a78cc-4c8b-4a32-a4dc-d92dbc782413",
+                        "name": "Sink",
+                        "class_name": "nos.utilities.Sink",
+                        "pins": [
+                            {
+                                "id": "d6fc00c2-6adc-44ce-83cf-69f94125e335",
+                                "name": "InExe",
+                                "type_name": "nos.exe",
+                                "show_as": "INPUT_PIN",
+                                "can_show_as": "INPUT_PIN_ONLY",
+                                "visualizer": {
+                                },
+                                "data": {},
+                                "def": {},
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {}
+                            },
+                            {
+                                "id": "053b9db4-b46b-4205-8f71-6fb34ab704f1",
+                                "name": "Sink Input",
+                                "type_name": "nos.Generic",
+                                "show_as": "INPUT_PIN",
+                                "can_show_as": "INPUT_PIN_ONLY",
+                                "visualizer": {
+                                },
+                                "data": {},
+                                "def": {},
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {},
+                                "display_name": "Output"
+                            },
+                            {
+                                "id": "2b5ae02f-1303-4b65-b0eb-3aa2db2b3151",
+                                "name": "Sink FPS",
+                                "type_name": "float",
+                                "show_as": "PROPERTY",
+                                "can_show_as": "PROPERTY_ONLY",
+                                "visualizer": {
+                                },
+                                "data": 60.0,
+                                "referred_by": [
+                                    "c7791cb8-9ed8-48b9-832d-190f43d0539f"
+                                ],
+                                "min": 0.01,
+                                "max": 1000.0,
+                                "def": 60.0,
+                                "step": 9.9999,
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {}
+                            },
+                            {
+                                "id": "d3dbc2e0-7d5a-4b51-8357-f233a1047844",
+                                "name": "Wait",
+                                "type_name": "bool",
+                                "show_as": "PROPERTY",
+                                "can_show_as": "PROPERTY_ONLY",
+                                "visualizer": {
+                                },
+                                "data": true,
+                                "def": true,
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {},
+                                "description": "Wait until gpu tasks(gpu nodes etc.) are completed."
+                            },
+                            {
+                                "id": "2e293aff-300d-4d6d-88e5-2c80324b9b23",
+                                "name": "AcceptsRepeat",
+                                "type_name": "bool",
+                                "show_as": "PROPERTY",
+                                "can_show_as": "PROPERTY_ONLY",
+                                "visualizer": {
+                                },
+                                "data": false,
+                                "referred_by": [
+                                    "6f9bbb5d-1eb7-4ae7-b2c0-1e43b0ef4b69"
+                                ],
+                                "def": false,
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {},
+                                "description": "Wait until GPU tasks are completed.",
+                                "display_name": "Accepts Repeat"
+                            },
+                            {
+                                "id": "ecd236af-11e9-4c4b-a302-efc16d0eb2be",
+                                "name": "SinkMode",
+                                "type_name": "nos.utilities.SinkMode",
+                                "show_as": "PROPERTY",
+                                "can_show_as": "PROPERTY_ONLY",
+                                "visualizer": {
+                                },
+                                "data": "Periodic",
+                                "referred_by": [
+                                    "52607932-ccf6-48fc-ac69-bb769a97efda"
+                                ],
+                                "def": "Periodic",
+                                "meta_data_map": [
+                                    {
+                                        "key": "Category",
+                                        "value": ""
+                                    }
+                                ],
+                                "contents_type": "JobPin",
+                                "contents": {},
+                                "description": "Whether to schedule nodes at an unlimited or fixed rate",
+                                "display_name": "Mode"
+                            },
+                            {
+                                "id": "d9040ed3-7494-4fce-aa3d-82cfd31fadf8",
+                                "name": "DropAfterSeconds",
+                                "type_name": "float",
+                                "show_as": "PROPERTY",
+                                "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                                "visualizer": {
+                                },
+                                "data": 1.0,
+                                "referred_by": [
+                                    "a9a32c7b-8907-4116-a252-c816d0be6c78"
+                                ],
+                                "def": 1.0,
+                                "contents_type": "JobPin",
+                                "contents": {},
+                                "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path after this many seconds",
+                                "display_name": "Drop After (Seconds)"
+                            }
+                        ],
+                        "pos": {
+                            "x": -554.0,
+                            "y": 128.0
+                        },
+                        "contents_type": "Job",
+                        "contents": { "type": "" },
+                        "function_category": "Default Node",
+                        "plugin_version": {
+                            "major": 3,
+                            "minor": 13,
+                            "patch": 1
+                        }
+                    }
+                ],
+                "connections": [
+                    {
+                        "from": "692cc43f-b55a-4384-ba2f-73d2d4af2dbc",
+                        "to": "d6fc00c2-6adc-44ce-83cf-69f94125e335",
+                        "id": "ffa56295-2077-4dcc-810a-592ca1a4ce38"
+                    },
+                    {
+                        "from": "b7a036be-3e8c-4846-9b53-e5d0dd1bae74",
+                        "to": "053b9db4-b46b-4205-8f71-6fb34ab704f1",
+                        "id": "050ed3c4-2acf-4388-a539-02e86353c1ba"
+                    }
+                ]
+            },
+            "function_category": "Default Node",
+            "meta_data_map": [
+                {
+                    "key": "PluginVersion",
+                    "value": "2.7.0"
+                },
+                {
+                    "key": "NodeStatusPortal",
+                    "value": "/Sink"
+                }
+            ],
+            "plugin_version": {
+                "major": 3,
+                "minor": 13,
+                "patch": 1
+            }
+        }
+    }
+  ] }

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -21,8 +21,11 @@ struct SinkNode : NodeContext
 	std::atomic<bool> Wait = true;
 	std::thread Thread;
 	bool AcceptRepeat = false;
-	clock::time_point LastCopy = clock::now();
 	utilities::SinkMode Mode = utilities::SinkMode::Periodic;
+	std::atomic<int64_t> PendingRequests = 0;
+	std::atomic<float> DropAfterSeconds = 1.0f;
+	bool HasDroppingMessage = false;
+
 
 	SinkNode(nosFbNodePtr inNode) : NodeContext(inNode)
 	{
@@ -35,8 +38,6 @@ struct SinkNode : NodeContext
 
 	nosResult ExecuteNode(nosNodeExecuteParams* params) override
 	{
-		auto& lastCopy = LastCopy;
-
 		if (nosVulkan)
 		{
 			nosCmd cmd{};
@@ -53,10 +54,10 @@ struct SinkNode : NodeContext
 			}
 		}
 
-		lastCopy = clock::now();
-
 		if (!IsPeriodic())
 			ScheduleNode();
+		else
+			PendingRequests--;
 
 		return NOS_RESULT_SUCCESS;
 	}
@@ -81,6 +82,10 @@ struct SinkNode : NodeContext
 		{
 			SetMode(*static_cast<utilities::SinkMode*>(value.Data));
 		}
+		if (NOS_NAME("DropAfterSeconds") == pinName)
+		{
+			DropAfterSeconds = *static_cast<float*>(value.Data);
+		}
 	}
 
 	void SetMode(utilities::SinkMode mode)
@@ -88,11 +93,14 @@ struct SinkNode : NodeContext
 		Mode = mode;
 		nosEngine.RecompilePath(NodeId);
 		auto fpsPinId = *GetPinId(NOS_NAME("Sink FPS"));
+		auto dropAfterSecondsPinId = *GetPinId(NOS_NAME("DropAfterSeconds"));
 		nosOrphanState orphanState{
 			.Type = !IsPeriodic() ? NOS_ORPHAN_STATE_TYPE_ORPHAN : NOS_ORPHAN_STATE_TYPE_ACTIVE,
 			.Message = !IsPeriodic() ? "Periodic mode is disabled" : ""
 		};
 		nosEngine.SetItemOrphanState(fpsPinId, &orphanState);
+		nosEngine.SetItemOrphanState(dropAfterSecondsPinId, &orphanState);
+		ClearNodeStatusMessages();
 	}
 
 	bool IsPeriodic()
@@ -116,6 +124,7 @@ struct SinkNode : NodeContext
 
 	void OnPathStart() override 
 	{
+		PendingRequests = 0;
 		if (!IsPeriodic())
 		{
 			StopThread();
@@ -138,31 +147,48 @@ struct SinkNode : NodeContext
 	void OnPathStop() override
 	{
 		if (IsPeriodic())
-			StartThread();
+			StopThread();
 	}
 
 	void SinkThread()
 	{
-		clock::time_point lastCopy;
+		clock::time_point start = clock::now();
+		clock::time_point lastSchedule;
+		bool dropped = false;
 		while (!ShouldStop)
 		{
 			auto now = clock::now();
 
-			float diff = std::chrono::duration_cast<std::chrono::microseconds>(now - lastCopy).count() / 1000.0f;
+			float diff = std::chrono::duration_cast<std::chrono::microseconds>(now - lastSchedule).count() / 1000.0f;
 			if (diff < 1000.f / Fps)
 				continue;
-			lastCopy = now;
-			flatbuffers::FlatBufferBuilder fbb;
-			std::vector<flatbuffers::Offset<app::AppEvent>> Offsets;
+			lastSchedule = now;
+			if (PendingRequests / Fps >= DropAfterSeconds)
+			{
+				nosEngine.LogE("Sink Node dropping frame, pending requests: %d, fps: %.2f, drop after seconds: %.2f",
+							   (int)PendingRequests.load(),
+							   Fps.load(),
+							   DropAfterSeconds.load());
+				SetNodeStatusMessage("Dropping", fb::NodeStatusMessageType::WARNING);
+				nosEngine.SendPathRestart(NodeId);
+				HasDroppingMessage = true;
+				dropped = true;
+				return;
+			}
+			if (HasDroppingMessage && !dropped)
+			{
+				if (now - start > std::chrono::milliseconds(int64_t(DropAfterSeconds.load() * 2.0 * 1000.0)))
+				{
+					ClearNodeStatusMessages();
+					HasDroppingMessage = false;
+				}
+			}
+			PendingRequests++;
 			{
 				std::unique_lock lock(Mutex);
 				if (ShouldStop)
 					break;
-				Offsets.push_back(CreateAppEventOffset(
-						fbb,
-						nos::app::CreateScheduleRequest(
-							fbb, nos::app::ScheduleRequestKind::NODE, &NodeId, 1)));
-				HandleEvent(CreateAppEvent(fbb, app::CreateBatchAppEventDirect(fbb, &Offsets)));
+				ScheduleNode();
 			}
 		}
 	}

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -163,7 +163,7 @@ struct SinkNode : NodeContext
 			if (diff < 1000.f / Fps)
 				continue;
 			lastSchedule = now;
-			if (PendingRequests / Fps >= DropAfterSeconds)
+			if ((float)PendingRequests.load() / Fps.load() >= DropAfterSeconds.load())
 			{
 				nosEngine.LogE("Sink Node dropping frame, pending requests: %d, fps: %.2f, drop after seconds: %.2f",
 							   (int)PendingRequests.load(),

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -23,7 +23,7 @@ struct SinkNode : NodeContext
 	bool AcceptRepeat = false;
 	utilities::SinkMode Mode = utilities::SinkMode::Periodic;
 	std::atomic<int64_t> PendingRequests = 0;
-	std::atomic<float> DropAfterSeconds = 1.0f;
+	std::atomic<float> LatencyBudget = 1.0f;
 	bool HasDroppingMessage = false;
 
 
@@ -82,9 +82,9 @@ struct SinkNode : NodeContext
 		{
 			SetMode(*static_cast<utilities::SinkMode*>(value.Data));
 		}
-		if (NOS_NAME("DropAfterSeconds") == pinName)
+		if (NOS_NAME("LatencyBudget") == pinName)
 		{
-			DropAfterSeconds = *static_cast<float*>(value.Data);
+			LatencyBudget = *static_cast<float*>(value.Data);
 		}
 	}
 
@@ -93,13 +93,13 @@ struct SinkNode : NodeContext
 		Mode = mode;
 		nosEngine.RecompilePath(NodeId);
 		auto fpsPinId = *GetPinId(NOS_NAME("Sink FPS"));
-		auto dropAfterSecondsPinId = *GetPinId(NOS_NAME("DropAfterSeconds"));
+		auto latencyBudgetPinId = *GetPinId(NOS_NAME("LatencyBudget"));
 		nosOrphanState orphanState{
 			.Type = !IsPeriodic() ? NOS_ORPHAN_STATE_TYPE_ORPHAN : NOS_ORPHAN_STATE_TYPE_ACTIVE,
 			.Message = !IsPeriodic() ? "Periodic mode is disabled" : ""
 		};
 		nosEngine.SetItemOrphanState(fpsPinId, &orphanState);
-		nosEngine.SetItemOrphanState(dropAfterSecondsPinId, &orphanState);
+		nosEngine.SetItemOrphanState(latencyBudgetPinId, &orphanState);
 		ClearNodeStatusMessages();
 	}
 
@@ -163,12 +163,12 @@ struct SinkNode : NodeContext
 			if (diff < 1000.f / Fps)
 				continue;
 			lastSchedule = now;
-			if ((float)PendingRequests.load() / Fps.load() >= DropAfterSeconds.load())
+			if ((float)PendingRequests.load() / Fps.load() >= LatencyBudget.load())
 			{
-				nosEngine.LogE("Sink Node dropping frame, pending requests: %d, fps: %.2f, drop after seconds: %.2f",
+				nosEngine.LogE("Sink Node dropping frame, pending requests: %d, fps: %.2f, latency budget: %.2f",
 							   (int)PendingRequests.load(),
 							   Fps.load(),
-							   DropAfterSeconds.load());
+							   LatencyBudget.load());
 				SetNodeStatusMessage("Dropping", fb::NodeStatusMessageType::WARNING);
 				nosEngine.SendPathRestart(NodeId);
 				HasDroppingMessage = true;
@@ -177,7 +177,7 @@ struct SinkNode : NodeContext
 			}
 			if (HasDroppingMessage && !dropped)
 			{
-				if (now - start > std::chrono::milliseconds(int64_t(DropAfterSeconds.load() * 2.0 * 1000.0)))
+				if (now - start > std::chrono::milliseconds(int64_t(LatencyBudget.load() * 2.0 * 1000.0)))
 				{
 					ClearNodeStatusMessages();
 					HasDroppingMessage = false;

--- a/Plugins/nosUtilities/Utilities.noscfg
+++ b/Plugins/nosUtilities/Utilities.noscfg
@@ -2,7 +2,7 @@
 	"info": {
 		"id": {
 			"name": "nos.utilities",
-			"version": "3.13.1"
+			"version": "3.14.0"
 		},
 		"description": "Various utility nodes.",
 		"display_name": "Utilities",


### PR DESCRIPTION
This was caused by delaying pin value changes until the pending path execution requests are completed. To fix this, sink now drops in periodic mode if it cannot fulfill the requests and shows dropping status.