### PR TITLE
Optimize sink to match performance with bounded queue/ring

### DIFF
--- a/Plugins/nosUtilities/Config/Sink.nosdef
+++ b/Plugins/nosUtilities/Config/Sink.nosdef
@@ -33,13 +33,13 @@
 						"max": 1000.0
 					},
 					{
-						"name": "Wait",
-						"type_name": "bool",
+						"name": "GPUFrameBuffering",
+						"type_name": "ulong",
 						"show_as": "PROPERTY",
 						"can_show_as": "PROPERTY_ONLY",
-						"data": true,
-						"description": "Wait until GPU tasks are completed",
-						"advanced_property": true
+						"data": 3,
+						"min": 1,
+						"description": "Number of frames to buffer on the GPU before waiting. Higher values can improve performance."
 					},
 					{
 						"name": "AcceptsRepeat",

--- a/Plugins/nosUtilities/Config/Sink.nosdef
+++ b/Plugins/nosUtilities/Config/Sink.nosdef
@@ -34,6 +34,7 @@
 					},
 					{
 						"name": "GPUFrameBuffering",
+						"display_name": "GPU Frame Buffering",
 						"type_name": "ulong",
 						"show_as": "PROPERTY",
 						"can_show_as": "PROPERTY_ONLY",

--- a/Plugins/nosUtilities/Config/Sink.nosdef
+++ b/Plugins/nosUtilities/Config/Sink.nosdef
@@ -33,6 +33,15 @@
 						"max": 1000.0
 					},
 					{
+						"name": "HasGPUWork",
+						"display_name": "Has GPU Work",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "PROPERTY_ONLY",
+						"data": true,
+						"description": "Whether operations in this path involve GPU work. If true, the sink will communicate with the GPU & do frame buffering."
+					},
+					{
 						"name": "GPUFrameBuffering",
 						"display_name": "GPU Frame Buffering",
 						"type_name": "ulong",

--- a/Plugins/nosUtilities/Config/SinkGraph.nosdef
+++ b/Plugins/nosUtilities/Config/SinkGraph.nosdef
@@ -1,450 +1,402 @@
 { "nodes": [
     {
-        "class_name": "SinkGraph",
+      "class_name": "SinkGraph",
         "menu_info": {
             "category": "Utilities",
             "display_name": "Threaded Sink"
         },
-        "node": {
-            "id": "9c4000ea-8fc7-4683-b257-2e16cea01b1a",
-            "name": "Sink",
-            "class_name": "nos.utilities.SinkGraph",
-            "pins": [
-                {
-                    "id": "aa8b2b61-086a-44f7-817f-90c75ef4da31",
-                    "name": "Sink Input",
-                    "type_name": "nos.Generic",
-                    "show_as": "INPUT_PIN",
-                    "can_show_as": "INPUT_PIN_ONLY",
-                    "visualizer": {
-                    },
-                    "data": {},
-                    "def": {},
-                    "meta_data_map": [
-                        {
-                            "key": "Category",
-                            "value": ""
-                        }
-                    ],
-                    "contents_type": "PortalPin",
-                    "contents": { "source_id": "47c5a6bf-30ec-45fb-8c18-5a3bf2432517" }
-                },
-                {
-                    "id": "c7791cb8-9ed8-48b9-832d-190f43d0539f",
-                    "name": "Sink FPS",
-                    "type_name": "float",
-                    "show_as": "PROPERTY",
-                    "can_show_as": "PROPERTY_ONLY",
-                    "visualizer": {
-                    },
-                    "data": 60.0,
-                    "min": 0.01,
-                    "max": 1000.0,
-                    "def": 60.0,
-                    "step": 9.9999,
-                    "meta_data_map": [
-                        {
-                            "key": "Category",
-                            "value": ""
-                        }
-                    ],
-                    "contents_type": "PortalPin",
-                    "contents": { "source_id": "2b5ae02f-1303-4b65-b0eb-3aa2db2b3151" },
-                    "display_name": "FPS"
-                },
-                {
-                    "id": "6f9bbb5d-1eb7-4ae7-b2c0-1e43b0ef4b69",
-                    "name": "AcceptsRepeat",
-                    "type_name": "bool",
-                    "show_as": "PROPERTY",
-                    "can_show_as": "PROPERTY_ONLY",
-                    "visualizer": {
-                    },
-                    "data": false,
-                    "def": false,
-                    "advanced_property": true,
-                    "meta_data_map": [
-                        {
-                            "key": "AdvancedProperty",
-                            "value": "true"
-                        },
-                        {
-                            "key": "Category",
-                            "value": ""
-                        }
-                    ],
-                    "contents_type": "PortalPin",
-                    "contents": { "source_id": "2e293aff-300d-4d6d-88e5-2c80324b9b23" },
-                    "display_name": "Accept Repeat"
-                },
-                {
-                    "id": "52607932-ccf6-48fc-ac69-bb769a97efda",
-                    "name": "SinkMode",
-                    "type_name": "nos.utilities.SinkMode",
-                    "show_as": "PROPERTY",
-                    "can_show_as": "PROPERTY_ONLY",
-                    "visualizer": {
-                    },
-                    "data": "Periodic",
-                    "def": "Periodic",
-                    "meta_data_map": [
-                        {
-                            "key": "Category",
-                            "value": ""
-                        }
-                    ],
-                    "contents_type": "PortalPin",
-                    "contents": { "source_id": "ecd236af-11e9-4c4b-a302-efc16d0eb2be" },
-                    "description": "Whether to schedule nodes at an unlimited or fixed rate",
-                    "display_name": "Mode"
-                },
-                {
-                    "id": "a9a32c7b-8907-4116-a252-c816d0be6c78",
-                    "name": "LatencyBudget",
-                    "type_name": "float",
-                    "show_as": "PROPERTY",
-                    "can_show_as": "INPUT_PIN_OR_PROPERTY",
-                    "visualizer": {
-                    },
-                    "data": 1.0,
-                    "def": 1.0,
-                    "min": 0.0,
-                    "contents_type": "PortalPin",
-                    "contents": { "source_id": "d9040ed3-7494-4fce-aa3d-82cfd31fadf8" },
-                    "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
-                    "display_name": "Latency Budget (Seconds)"
-                }
-            ],
-            "pos": {
-                "x": 0.0,
-                "y": 0.0
+      "node": {
+        "id": "da46167b-032c-4222-92a8-b129381ddfe1",
+        "name": "Sink",
+        "class_name": "SinkGraph",
+        "pins": [
+          {
+            "id": "019987de-1977-44d3-a729-0e626f568536",
+            "name": "Sink Input",
+            "type_name": "nos.sys.vulkan.Texture",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_ONLY",
+            "visualizer": {
             },
-            "contents_type": "Graph",
-            "contents": {
-                "nodes": [
-                    {
-                        "id": "9d9691ff-b630-4117-ab66-0834166b368a",
-                        "name": "Thread",
-                        "class_name": "nos.Thread",
-                        "always_execute": true,
-                        "pins": [
-                            {
-                                "id": "692cc43f-b55a-4384-ba2f-73d2d4af2dbc",
-                                "name": "Run",
-                                "type_name": "nos.exe",
-                                "show_as": "OUTPUT_PIN",
-                                "can_show_as": "OUTPUT_PIN_ONLY",
-                                "visualizer": {
-                                },
-                                "data": {},
-                                "def": {},
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "live": true,
-                                "contents_type": "JobPin",
-                                "contents": {}
-                            },
-                            {
-                                "id": "df233737-c6df-4897-8ee4-ca1d7d93d127",
-                                "name": "Importance",
-                                "type_name": "ulong",
-                                "show_as": "PROPERTY",
-                                "can_show_as": "PROPERTY_ONLY",
-                                "visualizer": {
-                                },
-                                "data": 0,
-                                "def": 0,
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {}
-                            }
-                        ],
-                        "pos": {
-                            "x": -738.0,
-                            "y": 89.0
-                        },
-                        "contents_type": "Job",
-                        "contents": { "type": "" },
-                        "function_category": "Default Node",
-                        "plugin_version": {
-                            "major": 0,
-                            "minor": 0,
-                            "patch": 0
-                        }
-                    },
-                    {
-                        "id": "9a8d1b3a-4097-4985-bcf5-07f153b111dc",
-                        "name": "Sink Input",
-                        "class_name": "nos.internal.GraphInput",
-                        "pins": [
-                            {
-                                "id": "b7a036be-3e8c-4846-9b53-e5d0dd1bae74",
-                                "name": "Output",
-                                "type_name": "nos.Generic",
-                                "show_as": "OUTPUT_PIN",
-                                "can_show_as": "OUTPUT_PIN_ONLY",
-                                "visualizer": {
-                                },
-                                "data": {},
-                                "def": {},
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {}
-                            },
-                            {
-                                "id": "47c5a6bf-30ec-45fb-8c18-5a3bf2432517",
-                                "name": "Input",
-                                "type_name": "nos.Generic",
-                                "show_as": "INPUT_PIN",
-                                "can_show_as": "INPUT_PIN_ONLY",
-                                "visualizer": {
-                                },
-                                "data": {},
-                                "referred_by": [
-                                    "aa8b2b61-086a-44f7-817f-90c75ef4da31"
-                                ],
-                                "def": {},
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    },
-                                    {
-                                        "key": "PinHidden",
-                                        "value": "true"
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {}
-                            }
-                        ],
-                        "pos": {
-                            "x": -938.0,
-                            "y": 108.5
-                        },
-                        "contents_type": "Job",
-                        "contents": { "type": "" },
-                        "function_category": "Default Node",
-                        "plugin_version": {
-                            "major": 0,
-                            "minor": 0,
-                            "patch": 0
-                        }
-                    },
-                    {
-                        "id": "860a78cc-4c8b-4a32-a4dc-d92dbc782413",
-                        "name": "Sink",
-                        "class_name": "nos.utilities.Sink",
-                        "pins": [
-                            {
-                                "id": "d6fc00c2-6adc-44ce-83cf-69f94125e335",
-                                "name": "InExe",
-                                "type_name": "nos.exe",
-                                "show_as": "INPUT_PIN",
-                                "can_show_as": "INPUT_PIN_ONLY",
-                                "visualizer": {
-                                },
-                                "data": {},
-                                "def": {},
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {}
-                            },
-                            {
-                                "id": "053b9db4-b46b-4205-8f71-6fb34ab704f1",
-                                "name": "Sink Input",
-                                "type_name": "nos.Generic",
-                                "show_as": "INPUT_PIN",
-                                "can_show_as": "INPUT_PIN_ONLY",
-                                "visualizer": {
-                                },
-                                "data": {},
-                                "def": {},
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {},
-                                "display_name": "Output"
-                            },
-                            {
-                                "id": "2b5ae02f-1303-4b65-b0eb-3aa2db2b3151",
-                                "name": "Sink FPS",
-                                "type_name": "float",
-                                "show_as": "PROPERTY",
-                                "can_show_as": "PROPERTY_ONLY",
-                                "visualizer": {
-                                },
-                                "data": 60.0,
-                                "referred_by": [
-                                    "c7791cb8-9ed8-48b9-832d-190f43d0539f"
-                                ],
-                                "min": 0.01,
-                                "max": 1000.0,
-                                "def": 60.0,
-                                "step": 9.9999,
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {}
-                            },
-                            {
-                                "id": "d3dbc2e0-7d5a-4b51-8357-f233a1047844",
-                                "name": "Wait",
-                                "type_name": "bool",
-                                "show_as": "PROPERTY",
-                                "can_show_as": "PROPERTY_ONLY",
-                                "visualizer": {
-                                },
-                                "data": true,
-                                "def": true,
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {},
-                                "description": "Wait until gpu tasks(gpu nodes etc.) are completed."
-                            },
-                            {
-                                "id": "2e293aff-300d-4d6d-88e5-2c80324b9b23",
-                                "name": "AcceptsRepeat",
-                                "type_name": "bool",
-                                "show_as": "PROPERTY",
-                                "can_show_as": "PROPERTY_ONLY",
-                                "visualizer": {
-                                },
-                                "data": false,
-                                "referred_by": [
-                                    "6f9bbb5d-1eb7-4ae7-b2c0-1e43b0ef4b69"
-                                ],
-                                "def": false,
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {},
-                                "description": "Wait until GPU tasks are completed.",
-                                "display_name": "Accepts Repeat"
-                            },
-                            {
-                                "id": "ecd236af-11e9-4c4b-a302-efc16d0eb2be",
-                                "name": "SinkMode",
-                                "type_name": "nos.utilities.SinkMode",
-                                "show_as": "PROPERTY",
-                                "can_show_as": "PROPERTY_ONLY",
-                                "visualizer": {
-                                },
-                                "data": "Periodic",
-                                "referred_by": [
-                                    "52607932-ccf6-48fc-ac69-bb769a97efda"
-                                ],
-                                "def": "Periodic",
-                                "meta_data_map": [
-                                    {
-                                        "key": "Category",
-                                        "value": ""
-                                    }
-                                ],
-                                "contents_type": "JobPin",
-                                "contents": {},
-                                "description": "Whether to schedule nodes at an unlimited or fixed rate",
-                                "display_name": "Mode"
-                            },
-                            {
-                                "id": "d9040ed3-7494-4fce-aa3d-82cfd31fadf8",
-                                "name": "LatencyBudget",
-                                "type_name": "float",
-                                "show_as": "PROPERTY",
-                                "can_show_as": "INPUT_PIN_OR_PROPERTY",
-                                "visualizer": {
-                                },
-                                "data": 1.0,
-                                "referred_by": [
-                                    "a9a32c7b-8907-4116-a252-c816d0be6c78"
-                                ],
-                                "def": 1.0,
-                                "min": 0.0,
-                                "contents_type": "JobPin",
-                                "contents": {},
-                                "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
-                                "display_name": "Latency Budget (Seconds)"
-                            }
-                        ],
-                        "pos": {
-                            "x": -554.0,
-                            "y": 128.0
-                        },
-                        "contents_type": "Job",
-                        "contents": { "type": "" },
-                        "function_category": "Default Node",
-                        "plugin_version": {
-                            "major": 3,
-                            "minor": 13,
-                            "patch": 1
-                        }
-                    }
-                ],
-                "connections": [
-                    {
-                        "from": "692cc43f-b55a-4384-ba2f-73d2d4af2dbc",
-                        "to": "d6fc00c2-6adc-44ce-83cf-69f94125e335",
-                        "id": "ffa56295-2077-4dcc-810a-592ca1a4ce38"
-                    },
-                    {
-                        "from": "b7a036be-3e8c-4846-9b53-e5d0dd1bae74",
-                        "to": "053b9db4-b46b-4205-8f71-6fb34ab704f1",
-                        "id": "050ed3c4-2acf-4388-a539-02e86353c1ba"
-                    }
-                ]
+            "data": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
             },
-            "function_category": "Default Node",
+            "def": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+            },
             "meta_data_map": [
+              { "key": "Category", "value": "" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "2714b0f2-6628-4b29-82f1-20c7603b0106" }
+          },
+          {
+            "id": "215a43c4-5c6a-4e40-92fd-457a072ae077",
+            "name": "Sink FPS",
+            "type_name": "float",
+            "show_as": "PROPERTY",
+            "can_show_as": "PROPERTY_ONLY",
+            "visualizer": {
+            },
+            "data": 60.0,
+            "min": 0.01,
+            "max": 1000.0,
+            "def": 60.0,
+            "step": 9.9999,
+            "meta_data_map": [
+              { "key": "Category", "value": "" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "c644cf48-5ef8-4d5a-b530-db2aaf78acc6" },
+            "display_name": "FPS"
+          },
+          {
+            "id": "14b02c55-b09f-4748-b74f-9a4f79cbff47",
+            "name": "AcceptsRepeat",
+            "type_name": "bool",
+            "show_as": "PROPERTY",
+            "can_show_as": "PROPERTY_ONLY",
+            "visualizer": {
+            },
+            "data": false,
+            "def": false,
+            "advanced_property": true,
+            "meta_data_map": [
+              { "key": "AdvancedProperty", "value": "true" },
+              { "key": "Category", "value": "" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "7e993484-6888-4c86-9a0b-385ad823c6b6" },
+            "display_name": "Accept Repeat"
+          },
+          {
+            "id": "6635fe07-8cd6-4e89-bc41-6f08fcadea1e",
+            "name": "SinkMode",
+            "type_name": "nos.utilities.SinkMode",
+            "show_as": "PROPERTY",
+            "can_show_as": "PROPERTY_ONLY",
+            "visualizer": {
+            },
+            "data": "Periodic",
+            "def": "Periodic",
+            "meta_data_map": [
+              { "key": "Category", "value": "" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "b718c069-fadd-45f6-ae68-230c232b9634" },
+            "description": "Whether to schedule nodes at an unlimited or fixed rate",
+            "display_name": "Mode"
+          },
+          {
+            "id": "d6be49d5-8a64-419a-927e-b4fc3d5470d3",
+            "name": "LatencyBudget",
+            "type_name": "float",
+            "show_as": "PROPERTY",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": 1.0,
+            "min": 0.0,
+            "def": 1.0,
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "cf11728e-4ca2-4a79-bcd5-f24cd300f45f" },
+            "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
+            "display_name": "Latency Budget (Seconds)"
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "8cc271d6-af2d-41f2-bd36-271da0492747",
+              "name": "Thread",
+              "class_name": "nos.Thread",
+              "always_execute": true,
+              "pins": [
                 {
-                    "key": "PluginVersion",
-                    "value": "2.7.0"
+                  "id": "e56973e7-4d24-45d6-907c-c8ff66ffce02",
+                  "name": "Run",
+                  "type_name": "nos.exe",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { },
+                  "def": { },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": { }
                 },
                 {
-                    "key": "NodeStatusPortal",
-                    "value": "/Sink"
+                  "id": "66afb2a7-976f-4374-b6f0-f47c366270c7",
+                  "name": "Importance",
+                  "type_name": "ulong",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0,
+                  "def": 0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
                 }
-            ],
-            "plugin_version": {
-                "major": 3,
-                "minor": 13,
-                "patch": 1
+              ],
+              "pos": { "x": -738.0, "y": 89.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "aa0821a9-bf7c-458b-9b67-90d9c54ac058",
+              "name": "Sink",
+              "class_name": "nos.utilities.Sink",
+              "pins": [
+                {
+                  "id": "1d016599-1378-47c0-b3d9-300f9e7e572b",
+                  "name": "InExe",
+                  "type_name": "nos.exe",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { },
+                  "def": { },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "e8e6b10b-8374-4732-bc63-587a24420fe3",
+                  "name": "Sink Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Output"
+                },
+                {
+                  "id": "c644cf48-5ef8-4d5a-b530-db2aaf78acc6",
+                  "name": "Sink FPS",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 60.0,
+                  "referred_by": [
+                    "215a43c4-5c6a-4e40-92fd-457a072ae077"
+                  ],
+                  "min": 0.01,
+                  "max": 1000.0,
+                  "def": 60.0,
+                  "step": 9.9999,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "7e993484-6888-4c86-9a0b-385ad823c6b6",
+                  "name": "AcceptsRepeat",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {
+                  },
+                  "data": false,
+                  "referred_by": [
+                    "14b02c55-b09f-4748-b74f-9a4f79cbff47"
+                  ],
+                  "def": false,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Accepts Repeat"
+                },
+                {
+                  "id": "b718c069-fadd-45f6-ae68-230c232b9634",
+                  "name": "SinkMode",
+                  "type_name": "nos.utilities.SinkMode",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {
+                  },
+                  "data": "Periodic",
+                  "referred_by": [
+                    "6635fe07-8cd6-4e89-bc41-6f08fcadea1e"
+                  ],
+                  "def": "Periodic",
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "description": "Whether to schedule nodes at an unlimited or fixed rate",
+                  "display_name": "Mode"
+                },
+                {
+                  "id": "cf11728e-4ca2-4a79-bcd5-f24cd300f45f",
+                  "name": "LatencyBudget",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "referred_by": [
+                    "d6be49d5-8a64-419a-927e-b4fc3d5470d3"
+                  ],
+                  "min": 0.0,
+                  "def": 1.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "description": "If schedule requests are arriving faster than they can be processed, the node will restart the path. This pins control the maximum time between request and fulfillment.",
+                  "display_name": "Latency Budget (Seconds)"
+                },
+                {
+                  "id": "c2c62a65-c485-4e54-9833-b2f4c54001b8",
+                  "name": "GPUFrameBuffering",
+                  "type_name": "ulong",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 3,
+                  "min": 1,
+                  "def": 3,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "description": "Number of frames to buffer on the GPU before waiting. Higher values can improve performance."
+                }
+              ],
+              "pos": { "x": -554.0, "y": 128.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 3, "minor": 14, "patch": 4 }
+            },
+            {
+              "id": "faeeb07f-6e77-442b-bcf7-ea4621cfa984",
+              "name": "Sink Input",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "6a9e04bb-9065-4e78-8405-1e33462598ba",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "2714b0f2-6628-4b29-82f1-20c7603b0106",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "referred_by": [
+                    "019987de-1977-44d3-a729-0e626f568536"
+                  ],
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" },
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -938.0, "y": 108.5 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
             }
-        }
+          ], "connections": [
+            { "from": "e56973e7-4d24-45d6-907c-c8ff66ffce02", "to": "1d016599-1378-47c0-b3d9-300f9e7e572b", "id": "5fba9526-bdd8-4e78-9bbe-34a855f333dc" },
+            { "from": "6a9e04bb-9065-4e78-8405-1e33462598ba", "to": "e8e6b10b-8374-4732-bc63-587a24420fe3", "id": "105625a0-9e04-4062-95b9-2aa3e0b39ffb" }
+          ] },
+        "function_category": "Default Node",
+        "meta_data_map": [
+          { "key": "NodeStatusPortal", "value": "/Sink" },
+          { "key": "PluginVersion", "value": "2.7.0" }
+        ],
+        "plugin_version": { "major": 3, "minor": 14, "patch": 4 }
+      }
     }
   ] }

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -25,6 +25,8 @@ struct SinkNode : NodeContext
 	std::atomic<int64_t> PendingRequests = 0;
 	std::atomic<float> LatencyBudget = 1.0f;
 	bool HasDroppingMessage = false;
+	std::vector<nosGPUEvent> GPUFrameSyncEvents;
+	uint64_t CurrentGPUEventIndex = 0;
 
 
 	SinkNode(nosFbNodePtr inNode) : NodeContext(inNode)
@@ -40,18 +42,20 @@ struct SinkNode : NodeContext
 	{
 		if (nosVulkan)
 		{
+			auto& gpuEvent = GPUFrameSyncEvents[CurrentGPUEventIndex];
 			nosCmd cmd{};
 			nosCmdBeginParams beginParams = {.Name = NOS_NAME("Sink Submit"), .AssociatedNodeId = NodeId, .OutCmdHandle = &cmd};
 			nosVulkan->Begin(&beginParams);
-			nosGPUEvent event{};
-			nosCmdEndParams endParams{ .ForceSubmit = true, .OutGPUEventHandle = Wait ? &event : nullptr };
+			nosCmdEndParams endParams{.ForceSubmit = true, .OutGPUEventHandle = &gpuEvent};
 			nosVulkan->End(cmd, &endParams);
-			if (Wait)
+			uint64_t nextGPUEventIndex = (CurrentGPUEventIndex + 1) % GPUFrameSyncEvents.size();
+			auto& nextGpuEvent = GPUFrameSyncEvents[nextGPUEventIndex];
+			if (nextGpuEvent)
 			{
-				util::Stopwatch sw;
-				nosVulkan->WaitGpuEvent(&event, 1000000000);
-				nosEngine.WatchLog("Sink GPU Wait", sw.ElapsedString().c_str());
+				nosVulkan->WaitGpuEvent(&nextGpuEvent, UINT64_MAX);
+				nextGpuEvent = {};
 			}
+			CurrentGPUEventIndex = nextGPUEventIndex;
 		}
 
 		if (!IsPeriodic())
@@ -85,6 +89,23 @@ struct SinkNode : NodeContext
 		if (NOS_NAME("LatencyBudget") == pinName)
 		{
 			LatencyBudget = *static_cast<float*>(value.Data);
+		}
+		if (NOS_NAME("GPUFrameBuffering") == pinName)
+		{
+			size_t newBufferSize = *static_cast<size_t*>(value.Data);
+			if (newBufferSize == 0)
+				newBufferSize = 1;
+			if (newBufferSize != GPUFrameSyncEvents.size())
+			{
+				for (auto& event : GPUFrameSyncEvents)
+				{
+					if (event)
+						nosVulkan->WaitGpuEvent(&event, 1000000000);
+					event = {};
+				}
+				GPUFrameSyncEvents.resize(newBufferSize);
+				CurrentGPUEventIndex = 0;
+			}
 		}
 	}
 
@@ -148,6 +169,13 @@ struct SinkNode : NodeContext
 	{
 		if (IsPeriodic())
 			StopThread();
+		// Wait all GPU events
+		for (auto& event : GPUFrameSyncEvents)
+		{
+			if (event)
+				nosVulkan->WaitGpuEvent(&event, 1000000000);
+			event = {};
+		}
 	}
 
 	void SinkThread()

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -13,6 +13,9 @@ namespace nos::utilities
 {
 using clock = std::chrono::high_resolution_clock;
 
+constexpr uint64_t VULKAN_TIMEOUT_BEFORE_LEAK =
+	3'000'000'000; // 3 seconds. This exists in case a GPU event is never signaled, we prefer to leak than hang forever.
+
 struct SinkNode : NodeContext
 {
 	std::mutex Mutex;
@@ -43,11 +46,7 @@ struct SinkNode : NodeContext
 							   {
 								   // Clear GPU events
 								   for (auto& event : *GPUFrameSyncEvents)
-								   {
-									   if (event)
-										   nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
-									   event = {};
-								   }
+									   DestroyGPUEvent(event);
 								   GPUFrameSyncEvents = std::nullopt;
 							   }
 							   else
@@ -66,11 +65,7 @@ struct SinkNode : NodeContext
 			if (GPUFrameBuffering != GPUFrameSyncEvents->size())
 			{
 				for (auto& event : *GPUFrameSyncEvents)
-				{
-					if (event)
-						nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
-					event = {};
-				}
+					DestroyGPUEvent(event);
 				GPUFrameSyncEvents->resize(GPUFrameBuffering);
 				CurrentGPUEventIndex = 0;
 			}
@@ -80,6 +75,18 @@ struct SinkNode : NodeContext
 	~SinkNode() override
 	{
 		StopThread();
+	}
+
+	void DestroyGPUEvent(nosGPUEvent& event)
+	{
+		if (event)
+		{
+			if (nosVulkan->WaitGpuEvent(&event, VULKAN_TIMEOUT_BEFORE_LEAK) != NOS_RESULT_SUCCESS)
+			{
+				nosEngine.LogW("Sink Node timed out waiting for GPU event during destruction, leaking the event to avoid hang.");
+			}
+			event = {};
+		}
 	}
 
 	nosResult ExecuteNode(nosNodeExecuteParams* params) override
@@ -200,9 +207,7 @@ struct SinkNode : NodeContext
 			// Wait all GPU events
 			for (auto& event : *GPUFrameSyncEvents)
 			{
-				if (event)
-					nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
-				event = {};
+				DestroyGPUEvent(event);
 			}
 		}
 	}

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -201,7 +201,7 @@ struct SinkNode : NodeContext
 			for (auto& event : *GPUFrameSyncEvents)
 			{
 				if (event)
-					nosVulkan->WaitGpuEvent(&event, 1000000000);
+					nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
 				event = {};
 			}
 		}

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -25,7 +25,7 @@ struct SinkNode : NodeContext
 	std::atomic<int64_t> PendingRequests = 0;
 	std::atomic<float> LatencyBudget = 1.0f;
 	bool HasDroppingMessage = false;
-	std::vector<nosGPUEvent> GPUFrameSyncEvents;
+	std::vector<nosGPUEvent> GPUFrameSyncEvents = std::vector<nosGPUEvent>(1);
 	uint64_t CurrentGPUEventIndex = 0;
 
 

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -25,12 +25,56 @@ struct SinkNode : NodeContext
 	std::atomic<int64_t> PendingRequests = 0;
 	std::atomic<float> LatencyBudget = 1.0f;
 	bool HasDroppingMessage = false;
-	std::vector<nosGPUEvent> GPUFrameSyncEvents = std::vector<nosGPUEvent>(1);
+	std::optional<std::vector<nosGPUEvent>> GPUFrameSyncEvents = std::nullopt;
+	size_t GPUFrameBuffering = 1;
 	uint64_t CurrentGPUEventIndex = 0;
 
 
-	SinkNode(nosFbNodePtr inNode) : NodeContext(inNode)
-	{
+	SinkNode(nosFbNodePtr inNode) : NodeContext(inNode) {
+		AddPinValueWatcher(NOS_NAME("HasGPUWork"),
+						   [this](nosBuffer const& newVal, std::optional<nos::Buffer> oldValue) {
+							   bool hasGpuWork = *static_cast<bool*>(newVal.Data);
+				SetPinOrphanState(NOS_NAME("GPUFrameBuffering"),
+								  hasGpuWork ? fb::PinOrphanStateType::ACTIVE : fb::PinOrphanStateType::ORPHAN,
+								  hasGpuWork ? nullptr : "Sink does not have GPU work to buffer.");
+							   if (hasGpuWork == GPUFrameSyncEvents.has_value())
+								   return;
+							   if (!hasGpuWork)
+							   {
+								   // Clear GPU events
+								   for (auto& event : *GPUFrameSyncEvents)
+								   {
+									   if (event)
+										   nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
+									   event = {};
+								   }
+								   GPUFrameSyncEvents = std::nullopt;
+							   }
+							   else
+							   {
+								   GPUFrameSyncEvents = std::vector<nosGPUEvent>(GPUFrameBuffering);
+								   CurrentGPUEventIndex = 0;
+							   }
+						   });
+		AddPinValueWatcher(NOS_NAME("GPUFrameBuffering"), [this](nosBuffer const& newVal, auto&&) {
+			size_t newBufferSize = *static_cast<size_t*>(newVal.Data);
+			if (newBufferSize == 0)
+				newBufferSize = 1;
+			GPUFrameBuffering = newBufferSize;
+			if (!GPUFrameSyncEvents.has_value())
+				return;
+			if (GPUFrameBuffering != GPUFrameSyncEvents->size())
+			{
+				for (auto& event : *GPUFrameSyncEvents)
+				{
+					if (event)
+						nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
+					event = {};
+				}
+				GPUFrameSyncEvents->resize(GPUFrameBuffering);
+				CurrentGPUEventIndex = 0;
+			}
+		});
 	}
 
 	~SinkNode() override
@@ -40,9 +84,9 @@ struct SinkNode : NodeContext
 
 	nosResult ExecuteNode(nosNodeExecuteParams* params) override
 	{
-		if (nosVulkan)
+		if (nosVulkan && GPUFrameSyncEvents)
 		{
-			auto& gpuEvent = GPUFrameSyncEvents[CurrentGPUEventIndex];
+			auto& gpuEvent = (*GPUFrameSyncEvents)[CurrentGPUEventIndex];
 			if (gpuEvent)
 			{
 				if (nosVulkan->WaitGpuEvent(&gpuEvent, 100'000'000) != NOS_RESULT_SUCCESS)
@@ -54,7 +98,7 @@ struct SinkNode : NodeContext
 			nosVulkan->Begin(&beginParams);
 			nosCmdEndParams endParams{.ForceSubmit = true, .OutGPUEventHandle = &gpuEvent};
 			nosVulkan->End(cmd, &endParams);
-			CurrentGPUEventIndex = (CurrentGPUEventIndex + 1) % GPUFrameSyncEvents.size();
+			CurrentGPUEventIndex = (CurrentGPUEventIndex + 1) % GPUFrameSyncEvents->size();
 		}
 
 		if (!IsPeriodic())
@@ -88,23 +132,6 @@ struct SinkNode : NodeContext
 		if (NOS_NAME("LatencyBudget") == pinName)
 		{
 			LatencyBudget = *static_cast<float*>(value.Data);
-		}
-		if (NOS_NAME("GPUFrameBuffering") == pinName)
-		{
-			size_t newBufferSize = *static_cast<size_t*>(value.Data);
-			if (newBufferSize == 0)
-				newBufferSize = 1;
-			if (newBufferSize != GPUFrameSyncEvents.size())
-			{
-				for (auto& event : GPUFrameSyncEvents)
-				{
-					if (event)
-						nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
-					event = {};
-				}
-				GPUFrameSyncEvents.resize(newBufferSize);
-				CurrentGPUEventIndex = 0;
-			}
 		}
 	}
 
@@ -168,12 +195,15 @@ struct SinkNode : NodeContext
 	{
 		if (IsPeriodic())
 			StopThread();
-		// Wait all GPU events
-		for (auto& event : GPUFrameSyncEvents)
+		if (GPUFrameSyncEvents)
 		{
-			if (event)
-				nosVulkan->WaitGpuEvent(&event, 1000000000);
-			event = {};
+			// Wait all GPU events
+			for (auto& event : *GPUFrameSyncEvents)
+			{
+				if (event)
+					nosVulkan->WaitGpuEvent(&event, 1000000000);
+				event = {};
+			}
 		}
 	}
 

--- a/Plugins/nosUtilities/Source/Sink.cpp
+++ b/Plugins/nosUtilities/Source/Sink.cpp
@@ -43,19 +43,18 @@ struct SinkNode : NodeContext
 		if (nosVulkan)
 		{
 			auto& gpuEvent = GPUFrameSyncEvents[CurrentGPUEventIndex];
+			if (gpuEvent)
+			{
+				if (nosVulkan->WaitGpuEvent(&gpuEvent, 100'000'000) != NOS_RESULT_SUCCESS)
+					return NOS_RESULT_PENDING;
+				gpuEvent = {};
+			}
 			nosCmd cmd{};
 			nosCmdBeginParams beginParams = {.Name = NOS_NAME("Sink Submit"), .AssociatedNodeId = NodeId, .OutCmdHandle = &cmd};
 			nosVulkan->Begin(&beginParams);
 			nosCmdEndParams endParams{.ForceSubmit = true, .OutGPUEventHandle = &gpuEvent};
 			nosVulkan->End(cmd, &endParams);
-			uint64_t nextGPUEventIndex = (CurrentGPUEventIndex + 1) % GPUFrameSyncEvents.size();
-			auto& nextGpuEvent = GPUFrameSyncEvents[nextGPUEventIndex];
-			if (nextGpuEvent)
-			{
-				nosVulkan->WaitGpuEvent(&nextGpuEvent, UINT64_MAX);
-				nextGpuEvent = {};
-			}
-			CurrentGPUEventIndex = nextGPUEventIndex;
+			CurrentGPUEventIndex = (CurrentGPUEventIndex + 1) % GPUFrameSyncEvents.size();
 		}
 
 		if (!IsPeriodic())
@@ -100,7 +99,7 @@ struct SinkNode : NodeContext
 				for (auto& event : GPUFrameSyncEvents)
 				{
 					if (event)
-						nosVulkan->WaitGpuEvent(&event, 1000000000);
+						nosVulkan->WaitGpuEvent(&event, UINT64_MAX);
 					event = {};
 				}
 				GPUFrameSyncEvents.resize(newBufferSize);

--- a/Plugins/nosUtilities/Utilities.noscfg
+++ b/Plugins/nosUtilities/Utilities.noscfg
@@ -2,7 +2,7 @@
 	"info": {
 		"id": {
 			"name": "nos.utilities",
-			"version": "3.14.4"
+			"version": "3.14.5"
 		},
 		"description": "Various utility nodes.",
 		"display_name": "Utilities",


### PR DESCRIPTION
The performance difference was caused by sink waiting for the GPU frame immediately after submittin(while the wait pin is checked). This commit adds gpu buffering to the Sink node with buffer amount controllable through a pin, also removes the wait pin and makes gpu buffering enabled by default.