### PR TITLE
Port nodos-1.3 plugin nodes to dev (SDK 41)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 [submodule "Plugins/nosCompositing/External/stb"]
 	path = Plugins/nosCompositing/External/stb
 	url = https://github.com/nothings/stb.git
+[submodule "Plugins/nosGeometry/External/openFBX"]
+	path = Plugins/nosGeometry/External/openFBX
+	url = https://github.com/nem0/OpenFBX.git
+[submodule "Plugins/nosUtilities/External/freetype"]
+	path = Plugins/nosUtilities/External/freetype
+	url = https://github.com/freetype/freetype.git

--- a/Plugins/nosFilters/Filters.nosplugin
+++ b/Plugins/nosFilters/Filters.nosplugin
@@ -2,7 +2,7 @@
     "info": {
         "id": {
             "name": "nos.filters",
-            "version": "3.0.0"
+            "version": "3.1.0"
         },
         "display_name": "Filters",
         "description": "Collection of image filters.",

--- a/Plugins/nosFilters/Nodes/BokehDof.nosnode
+++ b/Plugins/nosFilters/Nodes/BokehDof.nosnode
@@ -1,0 +1,121 @@
+{
+	"nodes": [
+		{
+			"class_name": "BokehDof",
+			"menu_info": {
+				"category": "Filters",
+				"display_name": "Bokeh DoF"
+			},
+			"node": {
+				"class_name": "BokehDof",
+				"name": "Bokeh DoF",
+				"description": "Single-pass 2D depth-of-field. CoC is computed from a linear view-space Z input; samples are gathered on a Vogel disc weighted by the BokehShape kernel texture, so bokeh takes the shape painted into BokehShape.",
+				"contents_type": "Job",
+				"contents": {
+					"type": "nos.sys.vulkan.GPUNode",
+					"options": {
+						"shader": "Shaders/BokehDof.frag"
+					}
+				},
+				"pins": [
+					{
+						"name": "Input",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"filtering": "LINEAR"
+						}
+					},
+					{
+						"name": "Depth",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"filtering": "NEAREST"
+						}
+					},
+					{
+						"name": "BokehShape",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"filtering": "LINEAR"
+						}
+					},
+					{
+						"name": "FocusDistance",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 5.0,
+						"min": 0.0,
+						"max": 1000.0
+					},
+					{
+						"name": "FocusRange",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 2.0,
+						"min": 0.01,
+						"max": 1000.0
+					},
+					{
+						"name": "MaxRadius",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 16.0,
+						"min": 0.0,
+						"max": 128.0
+					},
+					{
+						"name": "MinRadius",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.5,
+						"min": 0.0,
+						"max": 8.0
+					},
+					{
+						"name": "BackgroundIsFar",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 1.0,
+						"min": 0.0,
+						"max": 1.0
+					},
+					{
+						"name": "SampleCount",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 48.0,
+						"min": 4.0,
+						"max": 256.0
+					},
+					{
+						"name": "KernelRotation",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.0,
+						"min": -6.2832,
+						"max": 6.2832
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosFilters/Nodes/BokehShape.nosnode
+++ b/Plugins/nosFilters/Nodes/BokehShape.nosnode
@@ -1,0 +1,93 @@
+{
+	"nodes": [
+		{
+			"class_name": "BokehShape",
+			"menu_info": {
+				"category": "Filters",
+				"display_name": "Bokeh Shape"
+			},
+			"node": {
+				"class_name": "BokehShape",
+				"name": "Bokeh Shape",
+				"description": "Procedural bokeh kernel generator. Produces a unit-disc grayscale mask shaped like a regular polygon aperture (blade count, roundness, rotation), with soft edge and optional rim brightening. Feed the Output into a Bokeh DoF node's BokehShape pin.",
+				"contents_type": "Job",
+				"contents": {
+					"type": "nos.sys.vulkan.GPUNode",
+					"options": {
+						"shader": "Shaders/BokehShape.frag"
+					}
+				},
+				"pins": [
+					{
+						"name": "BladeCount",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 6.0,
+						"min": 0.0,
+						"max": 16.0
+					},
+					{
+						"name": "Roundness",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.3,
+						"min": 0.0,
+						"max": 1.0
+					},
+					{
+						"name": "Rotation",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.0,
+						"min": -6.2832,
+						"max": 6.2832
+					},
+					{
+						"name": "EdgeSoftness",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.04,
+						"min": 0.0,
+						"max": 0.5
+					},
+					{
+						"name": "RimBoost",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.0,
+						"min": 0.0,
+						"max": 4.0
+					},
+					{
+						"name": "RimWidth",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.08,
+						"min": 0.005,
+						"max": 0.5
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"data": {
+							"resolution": "CUSTOM",
+							"width": 128,
+							"height": 128,
+							"format": "R16_UNORM",
+							"usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET",
+							"filtering": "LINEAR"
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosFilters/Nodes/DepthOfField.nosnode
+++ b/Plugins/nosFilters/Nodes/DepthOfField.nosnode
@@ -1,0 +1,990 @@
+{ "nodes": [
+    {
+      "class_name": "nos.filters.DepthOfField",
+      "node": {
+        "id": "5899940c-437e-4f71-b119-bb80fb5d1e1a",
+        "name": "DepthOfField",
+        "class_name": "nos.filters.DepthOfField",
+        "pins": [
+          {
+            "id": "1950c2e6-a0f6-485b-8a02-bded8a2f6ed5",
+            "name": "Depth",
+            "type_name": "nos.sys.vulkan.Texture",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+            },
+            "def": {
+            },
+            "advanced_property": true,
+            "meta_data_map": [
+              { "key": "AdvancedProperty", "value": "true" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "74a1bfd0-4f2d-447b-945c-8d0cb67a2120" }
+          },
+          {
+            "id": "e0b8f433-212f-48f6-ba4f-c8a194e1a707",
+            "name": "FocusDistance",
+            "type_name": "float",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": 5.0,
+            "min": 0.0,
+            "max": 1000.0,
+            "def": 5.0,
+            "step": 10.0,
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "e709c7b4-9a59-4546-be53-0dc51abc5605" }
+          },
+          {
+            "id": "68187c92-92f3-40d0-8b24-df6f33f9f649",
+            "name": "FocusRange",
+            "type_name": "float",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": 2.0,
+            "min": 0.01,
+            "max": 1000.0,
+            "def": 2.0,
+            "step": 9.9999,
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "534a26e9-1ebd-4ed2-89fb-bdf5d34b6ec1" }
+          },
+          {
+            "id": "42554a0a-2d70-4ec4-a2ea-594ad71559f3",
+            "name": "MaxRadius",
+            "type_name": "float",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": 16.0,
+            "min": 0.0,
+            "max": 128.0,
+            "def": 16.0,
+            "step": 1.28,
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "63f77504-73aa-4b89-8849-65e27649b272" }
+          },
+          {
+            "id": "312c4450-a4ad-4690-ba3d-afcbc93da6eb",
+            "name": "MinRadius",
+            "type_name": "float",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": 0.5,
+            "min": 0.0,
+            "max": 8.0,
+            "def": 0.5,
+            "step": 0.08,
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "97561978-6da1-4a33-a6bc-c654008a8261" }
+          },
+          {
+            "id": "ce6c0d45-8ce1-47ef-bd73-addda06d826e",
+            "name": "Output",
+            "type_name": "nos.sys.vulkan.Texture",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+            },
+            "def": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+            },
+            "advanced_property": true,
+            "meta_data_map": [
+              { "key": "AdvancedProperty", "value": "true" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "c278680b-43b5-40ce-b1af-a4551c2e58f0" }
+          },
+          {
+            "id": "2be9d3ba-9386-43b0-ae1c-58168be2a289",
+            "name": "Input",
+            "type_name": "nos.sys.vulkan.Texture",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED",
+              "filtering": "LINEAR"
+            },
+            "def": {
+              "filtering": "LINEAR"
+            },
+            "advanced_property": true,
+            "meta_data_map": [
+              { "key": "AdvancedProperty", "value": "true" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "479248dc-200d-4a4d-87d2-f2c7c77f667f" }
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "393281e0-2cb8-4b90-a98e-a8e708719229",
+              "name": "Output",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "2e4ec877-e014-49ae-ae1d-881a0e4d1ac5",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "c278680b-43b5-40ce-b1af-a4551c2e58f0",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "referred_by": [
+                    "ce6c0d45-8ce1-47ef-bd73-addda06d826e"
+                  ],
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" },
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1329.0, "y": 1025.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "6a261add-ff1c-49ba-b9b7-a3bbad8e1fb3",
+              "name": "Directional DoF (1)",
+              "class_name": "nos.filters.DirectionalDof",
+              "pins": [
+                {
+                  "id": "b1b03fce-6863-42e6-a78a-260743b5441d",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET",
+                    "filtering": "LINEAR"
+                  },
+                  "def": {
+                    "filtering": "LINEAR"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "14aab6c6-10ce-4a39-9c6f-8c5633fe59e2",
+                  "name": "Depth",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "def": {
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "d6a91b7a-b576-487b-bd2c-89fee90a37d1",
+                  "name": "FocusDistance",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 7.4,
+                  "min": 0.0,
+                  "max": 1000.0,
+                  "def": 5.0,
+                  "step": 10.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "55bffdc3-e0fa-4c0f-9ead-5a3b96c232bf",
+                  "name": "FocusRange",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 3.1,
+                  "min": 0.01,
+                  "max": 1000.0,
+                  "def": 2.0,
+                  "step": 9.9999,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "bdc5ae5a-10cc-4c3c-b013-573a64bd8ec6",
+                  "name": "MaxRadius",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 5.0,
+                  "min": 0.0,
+                  "max": 128.0,
+                  "def": 16.0,
+                  "step": 1.28,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "d77d3716-69f5-4c5d-a342-414dc11597fb",
+                  "name": "MinRadius",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "min": 0.0,
+                  "max": 8.0,
+                  "def": 0.5,
+                  "step": 0.08,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ad25df82-1942-4f9f-a062-c072261a2d92",
+                  "name": "BackgroundIsFar",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "min": 0.0,
+                  "max": 1.0,
+                  "def": 1.0,
+                  "step": 0.01,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "aaff92e1-63fe-4253-8edb-1f34a76019c9",
+                  "name": "Direction",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 1.0 },
+                  "min": { "x": -1.0, "y": -1.0 },
+                  "max": { "x": 1.0, "y": 1.0 },
+                  "def": { "x": 1.0, "y": 0.0 },
+                  "step": 0.02,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ad6603e0-2b1d-4bf6-a1d1-af0fc05978a2",
+                  "name": "SampleCount",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 12.0,
+                  "min": 1.0,
+                  "max": 64.0,
+                  "def": 12.0,
+                  "step": 0.63,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "0ef0f439-9766-4957-8931-a02ce1019bd1",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1129.0, "y": 1073.0 },
+              "contents_type": "Job",
+              "contents": { "type": "nos.sys.vulkan.GPUNode", "options": { "shader": "Shaders/DirectionalDof.frag" } },
+              "function_category": "Default Node",
+              "description": "1D depth-aware blur. CoC is computed per pixel from a linear view-space Z input. Chain two instances along (1,0) and (0,1) for a separable disc bokeh.",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 0 }
+            },
+            {
+              "id": "deac982f-b51b-4ae0-b6c6-9b2998d3e5a9",
+              "name": "MaxRadius",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "d5387b2e-f8c6-4b2e-8a42-a11eed779a1d",
+                  "name": "Output",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 5.0,
+                  "min": 0.0,
+                  "max": 128.0,
+                  "def": 16.0,
+                  "step": 1.28,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "63f77504-73aa-4b89-8849-65e27649b272",
+                  "name": "Input",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 16.0,
+                  "referred_by": [
+                    "42554a0a-2d70-4ec4-a2ea-594ad71559f3"
+                  ],
+                  "min": 0.0,
+                  "max": 128.0,
+                  "def": 16.0,
+                  "step": 1.28,
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 655.0, "y": 1250.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "af576b2d-dde0-4d7b-86fc-37cb9f97b49e",
+              "name": "Directional DoF",
+              "class_name": "nos.filters.DirectionalDof",
+              "pins": [
+                {
+                  "id": "9e368dde-bb31-44d8-aaad-782e92fe2366",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED",
+                    "filtering": "LINEAR"
+                  },
+                  "def": {
+                    "filtering": "LINEAR"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "7e88a91a-1eca-4cc5-8dce-7c4aca61368d",
+                  "name": "Depth",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "def": {
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "c1b814c4-e424-40a0-99d6-0437d948d1d7",
+                  "name": "FocusDistance",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 7.4,
+                  "min": 0.0,
+                  "max": 1000.0,
+                  "def": 5.0,
+                  "step": 10.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "78893474-3dfc-4a36-b897-77760ba19c8c",
+                  "name": "FocusRange",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 3.1,
+                  "min": 0.01,
+                  "max": 1000.0,
+                  "def": 2.0,
+                  "step": 9.9999,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "4f471215-bebf-49be-a6e4-909c394d1f1a",
+                  "name": "MaxRadius",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 5.0,
+                  "min": 0.0,
+                  "max": 128.0,
+                  "def": 16.0,
+                  "step": 1.28,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "05132381-cf95-4253-9fc2-e87f84b70dd8",
+                  "name": "MinRadius",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "min": 0.0,
+                  "max": 8.0,
+                  "def": 0.5,
+                  "step": 0.08,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "2b52da00-b45d-41ae-a1ec-c88566879043",
+                  "name": "BackgroundIsFar",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "min": 0.0,
+                  "max": 1.0,
+                  "def": 1.0,
+                  "step": 0.01,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ac684e31-1a90-462f-8b64-2b368a93b563",
+                  "name": "Direction",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.0, "y": 0.0 },
+                  "min": { "x": -1.0, "y": -1.0 },
+                  "max": { "x": 1.0, "y": 1.0 },
+                  "def": { "x": 1.0, "y": 0.0 },
+                  "step": 0.02,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "b8527f03-5c5c-4a41-b485-fa05e0f50cb1",
+                  "name": "SampleCount",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 12.0,
+                  "min": 1.0,
+                  "max": 64.0,
+                  "def": 12.0,
+                  "step": 0.63,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "8f4d23a7-3b94-4a1c-ba14-d1ce47e92acd",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 855.0, "y": 977.0 },
+              "contents_type": "Job",
+              "contents": { "type": "nos.sys.vulkan.GPUNode", "options": { "shader": "Shaders/DirectionalDof.frag" } },
+              "function_category": "Default Node",
+              "description": "1D depth-aware blur. CoC is computed per pixel from a linear view-space Z input. Chain two instances along (1,0) and (0,1) for a separable disc bokeh.",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 0 }
+            },
+            {
+              "id": "8b497dab-5466-4d32-a440-125976e3a3ee",
+              "name": "Depth",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "9587b7b1-8fc7-437b-9459-ee73f90de097",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "def": {
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "74a1bfd0-4f2d-447b-945c-8d0cb67a2120",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED"
+                  },
+                  "referred_by": [
+                    "1950c2e6-a0f6-485b-8a02-bded8a2f6ed5"
+                  ],
+                  "def": {
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" },
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 655.0, "y": 1025.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "9813ee9d-1f75-4554-9f9c-b9ecafc2e9fe",
+              "name": "FocusDistance",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "7c60934b-ba19-4faf-9923-411511649cd0",
+                  "name": "Output",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 7.4,
+                  "min": 0.0,
+                  "max": 1000.0,
+                  "def": 5.0,
+                  "step": 10.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "e709c7b4-9a59-4546-be53-0dc51abc5605",
+                  "name": "Input",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 5.0,
+                  "referred_by": [
+                    "e0b8f433-212f-48f6-ba4f-c8a194e1a707"
+                  ],
+                  "min": 0.0,
+                  "max": 1000.0,
+                  "def": 5.0,
+                  "step": 10.0,
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 655.0, "y": 1100.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "2c0861b9-e416-4741-b56d-8dfa81c49516",
+              "name": "FocusRange",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "6a933bab-7bf6-4388-b990-abd1b9729e64",
+                  "name": "Output",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 3.1,
+                  "min": 0.01,
+                  "max": 1000.0,
+                  "def": 2.0,
+                  "step": 9.9999,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "534a26e9-1ebd-4ed2-89fb-bdf5d34b6ec1",
+                  "name": "Input",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 2.0,
+                  "referred_by": [
+                    "68187c92-92f3-40d0-8b24-df6f33f9f649"
+                  ],
+                  "min": 0.01,
+                  "max": 1000.0,
+                  "def": 2.0,
+                  "step": 9.9999,
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 655.0, "y": 1175.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "3951aaae-16df-4b07-b1a9-b8b2a01b19c7",
+              "name": "MinRadius",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "f0feee29-3782-49fe-a834-94e2b57916a8",
+                  "name": "Output",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "min": 0.0,
+                  "max": 8.0,
+                  "def": 0.5,
+                  "step": 0.08,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "97561978-6da1-4a33-a6bc-c654008a8261",
+                  "name": "Input",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.5,
+                  "referred_by": [
+                    "312c4450-a4ad-4690-ba3d-afcbc93da6eb"
+                  ],
+                  "min": 0.0,
+                  "max": 8.0,
+                  "def": 0.5,
+                  "step": 0.08,
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 655.0, "y": 1325.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "a1d16ddd-0144-4daa-97b2-e9b3b019c8c1",
+              "name": "Input",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "c271ac23-2923-45c2-b262-b654455a93c3",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED",
+                    "filtering": "LINEAR"
+                  },
+                  "def": {
+                    "filtering": "LINEAR"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "479248dc-200d-4a4d-87d2-f2c7c77f667f",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED",
+                    "filtering": "LINEAR"
+                  },
+                  "referred_by": [
+                    "2be9d3ba-9386-43b0-ae1c-58168be2a289"
+                  ],
+                  "def": {
+                    "filtering": "LINEAR"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    { "key": "AdvancedProperty", "value": "true" },
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 655.0, "y": 1400.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "connections": [
+            { "from": "8f4d23a7-3b94-4a1c-ba14-d1ce47e92acd", "to": "b1b03fce-6863-42e6-a78a-260743b5441d", "id": "83839676-0760-4699-ae80-c0a789e273d8" },
+            { "from": "f0feee29-3782-49fe-a834-94e2b57916a8", "to": "d77d3716-69f5-4c5d-a342-414dc11597fb", "id": "4c05135f-6001-4679-b39c-b248559ae56d" },
+            { "from": "9587b7b1-8fc7-437b-9459-ee73f90de097", "to": "14aab6c6-10ce-4a39-9c6f-8c5633fe59e2", "id": "231cdfe5-7ac7-4013-9d20-68d5af8509b7" },
+            { "from": "7c60934b-ba19-4faf-9923-411511649cd0", "to": "d6a91b7a-b576-487b-bd2c-89fee90a37d1", "id": "1cdaef73-876c-472a-97ff-04bf1f01348e" },
+            { "from": "c271ac23-2923-45c2-b262-b654455a93c3", "to": "9e368dde-bb31-44d8-aaad-782e92fe2366", "id": "231fc88c-a52e-48d0-a6ee-8c2fdfe3ef0d" },
+            { "from": "6a933bab-7bf6-4388-b990-abd1b9729e64", "to": "55bffdc3-e0fa-4c0f-9ead-5a3b96c232bf", "id": "7c1cae59-5834-420e-9d3d-e4767f6c3273" },
+            { "from": "d5387b2e-f8c6-4b2e-8a42-a11eed779a1d", "to": "bdc5ae5a-10cc-4c3c-b013-573a64bd8ec6", "id": "d74bdb3a-8c8c-4f82-8038-01a237e27a89" },
+            { "from": "0ef0f439-9766-4957-8931-a02ce1019bd1", "to": "2e4ec877-e014-49ae-ae1d-881a0e4d1ac5", "id": "353cc954-d098-417a-8331-357b879ba654" },
+            { "from": "9587b7b1-8fc7-437b-9459-ee73f90de097", "to": "7e88a91a-1eca-4cc5-8dce-7c4aca61368d", "id": "b126f4c4-d748-46f2-be51-ce1c778c0c4b" },
+            { "from": "7c60934b-ba19-4faf-9923-411511649cd0", "to": "c1b814c4-e424-40a0-99d6-0437d948d1d7", "id": "fc25a2f4-0af4-49ae-9052-133a76cfc044" },
+            { "from": "6a933bab-7bf6-4388-b990-abd1b9729e64", "to": "78893474-3dfc-4a36-b897-77760ba19c8c", "id": "f6ba18f8-0ef1-42db-a774-c4b02aa78fac" },
+            { "from": "d5387b2e-f8c6-4b2e-8a42-a11eed779a1d", "to": "4f471215-bebf-49be-a6e4-909c394d1f1a", "id": "afd9d7ff-f9e2-4a67-b874-2cfb2f870447" },
+            { "from": "f0feee29-3782-49fe-a834-94e2b57916a8", "to": "05132381-cf95-4253-9fc2-e87f84b70dd8", "id": "82919455-4a51-490a-8ab2-201952d2e126" }
+          ] },
+        "function_category": "Default Node",
+        "display_name": "Depth of Field",
+        "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosFilters/Nodes/DirectionalDof.nosnode
+++ b/Plugins/nosFilters/Nodes/DirectionalDof.nosnode
@@ -1,0 +1,121 @@
+{
+	"nodes": [
+		{
+			"class_name": "DirectionalDof",
+			"menu_info": {
+				"category": "Filters",
+				"display_name": "Directional DoF"
+			},
+			"node": {
+				"class_name": "DirectionalDof",
+				"name": "Directional DoF",
+				"description": "1D depth-aware blur. CoC is computed per pixel from a linear view-space Z input. Chain two instances along (1,0) and (0,1) for a separable disc bokeh.",
+				"contents_type": "Job",
+				"contents": {
+					"type": "nos.sys.vulkan.GPUNode",
+					"options": {
+						"shader": "Shaders/DirectionalDof.frag"
+					}
+				},
+				"pins": [
+					{
+						"name": "Input",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"filtering": "LINEAR"
+						}
+					},
+					{
+						"name": "Depth",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"filtering": "NEAREST"
+						}
+					},
+					{
+						"name": "FocusDistance",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 5.0,
+						"min": 0.0,
+						"max": 1000.0
+					},
+					{
+						"name": "FocusRange",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 2.0,
+						"min": 0.01,
+						"max": 1000.0
+					},
+					{
+						"name": "MaxRadius",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 16.0,
+						"min": 0.0,
+						"max": 128.0
+					},
+					{
+						"name": "MinRadius",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.5,
+						"min": 0.0,
+						"max": 8.0
+					},
+					{
+						"name": "BackgroundIsFar",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 1.0,
+						"min": 0.0,
+						"max": 1.0
+					},
+					{
+						"name": "Direction",
+						"type_name": "nos.fb.vec2",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"x": 1.0,
+							"y": 0.0
+						},
+						"min": {
+							"x": -1.0,
+							"y": -1.0
+						},
+						"max": {
+							"x": 1.0,
+							"y": 1.0
+						}
+					},
+					{
+						"name": "SampleCount",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 12.0,
+						"min": 1.0,
+						"max": 64.0
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosFilters/Shaders/BokehDof.frag
+++ b/Plugins/nosFilters/Shaders/BokehDof.frag
@@ -1,0 +1,105 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+// Single-pass 2D bokeh depth-of-field with a kernel-texture shaping the bokeh.
+//
+// Computes a per-pixel circle of confusion (CoC) from a linear view-space Z
+// input, then gathers samples on a Vogel (golden-angle) disc within that CoC.
+// Each sample's contribution is weighted by BokehShape sampled at the same
+// unit-disc position, so the bokeh takes on the shape painted into BokehShape
+// (regular polygon, ring, custom artwork, etc.).
+
+#version 450
+
+#define MASK_THRESHOLD 0.001
+#define GOLDEN_ANGLE   2.39996322972865332
+
+layout(binding = 0) uniform sampler2D Input;
+layout(binding = 1) uniform sampler2D Depth;
+layout(binding = 2) uniform sampler2D BokehShape;
+layout(binding = 3) uniform BokehDofParams
+{
+    // Focus distance in the same units as the Depth input (linear view-space Z).
+    float FocusDistance;
+    // Distance from focus where CoC reaches MaxRadius.
+    float FocusRange;
+    // Maximum CoC radius in pixels.
+    float MaxRadius;
+    // Skip the gather when CoC <= MinRadius (keeps focused regions crisp & cheap).
+    float MinRadius;
+    // 0 = treat zero depth as "near focus" (stays sharp); 1 = treat as far plane.
+    float BackgroundIsFar;
+    // Total Vogel-disc sample count. ~32 = soft, ~64 = clean, ~128 = no banding.
+    float SampleCount;
+    // Rotate the kernel lookup (radians). Useful for animated highlights.
+    float KernelRotation;
+}
+Params;
+
+layout(location = 0) out vec4 rt;
+layout(location = 0) in vec2 uv;
+
+float CocFromDepth(float Z)
+{
+    if (Z <= 0.0)
+        Z = mix(Params.FocusDistance, Params.FocusDistance + Params.FocusRange * 4.0, Params.BackgroundIsFar);
+
+    float D   = abs(Z - Params.FocusDistance);
+    float Coc = D / max(Params.FocusRange, 1e-4);
+    return clamp(Coc * Params.MaxRadius, 0.0, Params.MaxRadius);
+}
+
+void main()
+{
+    vec2 TextureSize = textureSize(Input, 0);
+    vec2 TexelSize   = 1.0 / TextureSize;
+
+    vec4  CenterColor = texture(Input, uv);
+    float CenterZ     = texture(Depth, uv).r;
+    float CenterCoC   = CocFromDepth(CenterZ);
+
+    if (CenterCoC <= Params.MinRadius || Params.MaxRadius < MASK_THRESHOLD)
+    {
+        rt = CenterColor;
+        return;
+    }
+
+    int   N        = int(max(1.0, Params.SampleCount));
+    float CosR     = cos(Params.KernelRotation);
+    float SinR     = sin(Params.KernelRotation);
+
+    // Vogel disc: golden-angle spiral with sqrt radius for uniform area density.
+    // Sample 0 is the center; included implicitly via CenterColor initialization.
+    vec4  Accum  = CenterColor;
+    float Weight = texture(BokehShape, vec2(0.5)).r;
+    Accum       *= Weight;
+
+    for (int i = 1; i < N; ++i)
+    {
+        float Frac = float(i) / float(N);
+        float R    = sqrt(Frac);                          // unit-disc radius
+        float Th   = float(i) * GOLDEN_ANGLE;
+        vec2  Unit = vec2(cos(Th) * R, sin(Th) * R);      // unit disc position
+
+        // Rotated lookup into the bokeh kernel.
+        vec2 ShapeUv = vec2(Unit.x * CosR - Unit.y * SinR,
+                            Unit.x * SinR + Unit.y * CosR) * 0.5 + 0.5;
+        float WShape = texture(BokehShape, ShapeUv).r;
+        if (WShape <= MASK_THRESHOLD)
+            continue;
+
+        vec2  Ofs    = Unit * CenterCoC * TexelSize;
+        vec4  Sample = texture(Input, uv + Ofs);
+        float ZSamp  = texture(Depth, uv + Ofs).r;
+        float CocSmp = CocFromDepth(ZSamp);
+
+        // Per-sample CoC rejection prevents in-focus pixels bleeding outward.
+        // A sample contributes only if its own CoC is at least its distance from center.
+        float Dist = R * CenterCoC;
+        float WCoc = Dist <= CocSmp ? 1.0 : 0.0;
+
+        float W = WShape * WCoc;
+        Accum  += Sample * W;
+        Weight += W;
+    }
+
+    rt = Accum / max(Weight, 1e-4);
+}

--- a/Plugins/nosFilters/Shaders/BokehShape.frag
+++ b/Plugins/nosFilters/Shaders/BokehShape.frag
@@ -1,0 +1,77 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+// Procedural bokeh kernel generator.
+//
+// Produces a grayscale unit-disc mask shaped like a regular polygon aperture
+// (number of blades configurable) with optional roundness, rotation, soft edge
+// and brightened rim. Intended as input to a kernel-weighted DoF gather.
+//
+// Convention: image is treated as the [-1, 1] unit square; pixels outside the
+// kernel shape return 0; pixels inside return ~1, with a smooth edge falloff
+// over EdgeSoftness. The mask is normalized so that center stays at 1.
+
+#version 450
+
+#define PI 3.14159265358979323846
+
+layout(location = 0) out vec4 rt;
+layout(location = 0) in vec2 uv;
+
+layout(binding = 1) uniform BokehShapeParams
+{
+    // Aperture blade count. 0 or 1 = perfect circle.
+    float BladeCount;
+    // 0 = sharp polygon, 1 = perfect circle. Interpolates polygon edge toward disc.
+    float Roundness;
+    // Rotation of the polygon (radians).
+    float Rotation;
+    // Soft falloff width at the edge, in [0, 1] of unit-disc radius.
+    float EdgeSoftness;
+    // Extra brightness boost near the rim, [0, 1]. Mimics cat's-eye / specular bokeh.
+    float RimBoost;
+    // Width of the rim brightening band, in [0, 1] of radius.
+    float RimWidth;
+}
+Params;
+
+void main()
+{
+    // Map uv [0,1] to centered coords [-1,1]
+    vec2  Pos = uv * 2.0 - 1.0;
+    float R   = length(Pos);
+
+    if (R > 1.0)
+    {
+        rt = vec4(0.0);
+        return;
+    }
+
+    float Blades = max(Params.BladeCount, 1.0);
+
+    // Polygon edge radius along this angular direction.
+    // sectorAngle = 2*pi / N; angle from sector center is a; edge distance = cos(pi/N) / cos(a).
+    float PolygonR = 1.0;
+    if (Blades >= 3.0)
+    {
+        float Theta       = atan(Pos.y, Pos.x) - Params.Rotation;
+        float SectorAngle = 2.0 * PI / Blades;
+        float HalfSector  = SectorAngle * 0.5;
+        // Angle measured from the nearest sector centerline, in [-HalfSector, +HalfSector].
+        float A = mod(Theta + HalfSector, SectorAngle) - HalfSector;
+        PolygonR = cos(HalfSector) / max(cos(A), 1e-4);
+    }
+
+    // Roundness mixes polygon edge toward the circumscribed circle (radius 1).
+    float EdgeR = mix(PolygonR, 1.0, clamp(Params.Roundness, 0.0, 1.0));
+
+    // Soft edge: 1 inside, 0 past the edge, smooth across EdgeSoftness.
+    float Soft = max(Params.EdgeSoftness, 1e-4);
+    float Mask = 1.0 - smoothstep(EdgeR - Soft, EdgeR, R);
+
+    // Rim brightening: a soft band just inside the edge.
+    float RimW   = max(Params.RimWidth, 1e-4);
+    float RimPos = (R - (EdgeR - RimW)) / RimW;            // 0 at inner edge of rim, 1 at outer
+    float Rim    = clamp(1.0 - abs(RimPos * 2.0 - 1.0), 0.0, 1.0);
+    Mask        += Rim * Params.RimBoost * Mask;
+
+    rt = vec4(Mask, Mask, Mask, 1.0);
+}

--- a/Plugins/nosFilters/Shaders/DirectionalDof.frag
+++ b/Plugins/nosFilters/Shaders/DirectionalDof.frag
@@ -1,0 +1,95 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+// Directional depth-of-field pass.
+// Computes circle-of-confusion (CoC) per pixel from a linear view-space Z input,
+// then does a 1D weighted gather along Direction. Chain two instances
+// (Direction = (1,0) and Direction = (0,1)) for a separable approximation of
+// disc bokeh; visually close to a gaussian bokeh and cheap.
+
+#version 450
+
+#define MASK_THRESHOLD 0.001
+
+layout(binding = 0) uniform sampler2D Input;
+layout(binding = 1) uniform sampler2D Depth;
+layout(binding = 2) uniform DirectionalDofParams
+{
+    // Focus distance in the same units as the Depth input (linear view-space Z).
+    float FocusDistance;
+    // Distance from focus where CoC reaches MaxRadius.
+    // Smaller value = sharper focus falloff; larger = gentler.
+    float FocusRange;
+    // Maximum CoC radius in pixels.
+    float MaxRadius;
+    // 0 = treat zero depth as "no info, keep sharp"; 1 = treat zero depth as far.
+    float BackgroundIsFar;
+    vec2 Direction;
+    // Optional: clamp CoC near the focus plane to avoid noise; raise to skip tiny blurs.
+    float MinRadius;
+    // Sample count along the direction (one side; total taps = 2*N+1). Higher = smoother.
+    float SampleCount;
+}
+Params;
+
+layout(location = 0) out vec4 rt;
+layout(location = 0) in vec2 uv;
+
+float CocFromDepth(float Z)
+{
+    // Treat Z<=0 (no depth signal) as either "near focus" (BackgroundIsFar=0)
+    // or as far plane (BackgroundIsFar=1). Picking far avoids halos around empty regions.
+    if (Z <= 0.0)
+        Z = mix(Params.FocusDistance, Params.FocusDistance + Params.FocusRange * 4.0, Params.BackgroundIsFar);
+
+    float D   = abs(Z - Params.FocusDistance);
+    float Coc = D / max(Params.FocusRange, 1e-4);
+    Coc       = clamp(Coc * Params.MaxRadius, 0.0, Params.MaxRadius);
+    return Coc;
+}
+
+void main()
+{
+    vec2 TextureSize = textureSize(Input, 0);
+    vec2 TexelSize   = 1.0 / TextureSize;
+
+    vec4  CenterColor = texture(Input, uv);
+    float CenterZ     = texture(Depth, uv).r;
+    float CenterCoC   = CocFromDepth(CenterZ);
+
+    if (CenterCoC <= Params.MinRadius || Params.MaxRadius < MASK_THRESHOLD)
+    {
+        rt = CenterColor;
+        return;
+    }
+
+    vec2 Dir = normalize(Params.Direction);
+
+    int   N        = int(max(1.0, Params.SampleCount));
+    float RadiusPx = CenterCoC;
+    float Step     = RadiusPx / float(N);
+
+    // Box-weighted average; for separable-2D this gives a soft disc.
+    // CoC-clamping per sample prevents fragments in focus from bleeding outward.
+    vec4  Accum  = CenterColor;
+    float Weight = 1.0;
+
+    for (int i = 1; i <= N; ++i)
+    {
+        float T      = float(i) * Step;
+        vec2  Ofs    = Dir * T * TexelSize;
+
+        vec4  SPos   = texture(Input, uv + Ofs);
+        float ZPos   = texture(Depth, uv + Ofs).r;
+        float CocPos = CocFromDepth(ZPos);
+        float WPos   = Step <= CocPos ? 1.0 : 0.0;
+
+        vec4  SNeg   = texture(Input, uv - Ofs);
+        float ZNeg   = texture(Depth, uv - Ofs).r;
+        float CocNeg = CocFromDepth(ZNeg);
+        float WNeg   = Step <= CocNeg ? 1.0 : 0.0;
+
+        Accum  += SPos * WPos + SNeg * WNeg;
+        Weight += WPos + WNeg;
+    }
+
+    rt = Accum / Weight;
+}

--- a/Plugins/nosGeometry/CMakeLists.txt
+++ b/Plugins/nosGeometry/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+# OpenFBX (submodule under External/openFBX), used to read object transforms out of
+# .fbx files. Built under a plugin-unique target name so it never clashes with an
+# "openFBX" target another plugin may create.
+if (NOT TARGET nosGeometry_openFBX)
+    add_library(nosGeometry_openFBX STATIC
+        External/openFBX/src/libdeflate.c
+        External/openFBX/src/ofbx.cpp)
+    target_include_directories(nosGeometry_openFBX PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/External/openFBX/src")
+    nos_group_targets("nosGeometry_openFBX" "External")
+endif()
+
+target_link_libraries(${NOS_PLUGIN_TARGET} PRIVATE nosGeometry_openFBX)
+
+# CoordinateFrameConversion.hpp helpers need C++20
+set_target_properties(${NOS_PLUGIN_TARGET} PROPERTIES CXX_STANDARD 20)

--- a/Plugins/nosGeometry/Geometry.nosplugin
+++ b/Plugins/nosGeometry/Geometry.nosplugin
@@ -1,0 +1,23 @@
+{
+	"info": {
+		"id": {
+			"name": "nos.geometry",
+			"version": "0.1.0"
+		},
+		"display_name": "Geometry",
+		"description": "Nodes for reading 3D assets (FBX) and 3D geometry operations.",
+		"category": "Geometry",
+		"dependencies": [
+			{
+				"name": "nos.track",
+				"version": "3.0"
+			}
+		]
+	},
+	"named_values": [
+		"Types/CoordinateSystemPresets.json"
+	],
+	"binary_path": "Binaries/nosGeometry",
+	"sdk_version": "41.0",
+	"schema_version": "1.4-v1"
+}

--- a/Plugins/nosGeometry/Nodes/ReadFBXTransform.nosnode
+++ b/Plugins/nosGeometry/Nodes/ReadFBXTransform.nosnode
@@ -1,0 +1,108 @@
+{
+	"nodes": [
+		{
+			"class_name": "ReadFBXTransform",
+			"menu_info": {
+				"category": "Geometry",
+				"display_name": "Read FBX Transform",
+				"name_aliases": [ "FBX", "Load FBX", "FBX Transform", "FBX Reader" ]
+			},
+			"node": {
+				"class_name": "ReadFBXTransform",
+				"contents_type": "Job",
+				"description": "Reads an .fbx file and outputs the local and global transform of a\nselected object, converted into the chosen Output Frame. Pick the object\nfrom the 'Object' dropdown, which is populated with the names found in the\nfile. The file's own coordinate frame is detected from its header; turn off\n'Auto-Detect Source' to declare it manually.",
+				"pins": [
+					{
+						"name": "Path",
+						"type_name": "string",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": {
+							"type": "FILE_PICKER",
+							"file_extensions": [ "fbx" ],
+							"file_picker_type": "OPEN"
+						},
+						"description": "Path to the .fbx file to read."
+					},
+					{
+						"name": "Object",
+						"type_name": "string",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": "",
+						"visualizer": {
+							"type": "COMBO_BOX",
+							"name": ""
+						},
+						"description": "Object inside the .fbx whose transform is reported.\nThe list is populated once the file is loaded."
+					},
+					{
+						"name": "OutputFrame",
+						"display_name": "Output Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.geometry.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system the output transforms are expressed in. The node converts\nfrom the file's system (see 'Auto-Detect Source') into this one, including a\nunit change derived from the two systems' meters_per_unit."
+					},
+					{
+						"name": "AutoDetectSource",
+						"display_name": "Auto-Detect Source",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": true,
+						"description": "When on, the source system is read from the .fbx header (its up-axis,\nhandedness and unit scale). When off, the 'Source Frame' pin is used instead."
+					},
+					{
+						"name": "SourceFrame",
+						"display_name": "Source Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.geometry.CoordinateSystemPresets" },
+						"data": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+						"description": "Coordinate system the .fbx is authored in. Used only when 'Auto-Detect\nSource' is off; otherwise the detected system (see 'Detected Frame') wins."
+					},
+					{
+						"name": "LocalTransform",
+						"display_name": "Local Transform",
+						"type_name": "nos.track.TransformQ",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "Transform of the object relative to its parent, in the Output Frame."
+					},
+					{
+						"name": "GlobalTransform",
+						"display_name": "Global Transform",
+						"type_name": "nos.track.TransformQ",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "World transform of the object, accounting for its parent hierarchy,\nin the Output Frame."
+					},
+					{
+						"name": "DetectedFrame",
+						"display_name": "Detected Frame",
+						"type_name": "string",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"data": "",
+						"readonly": true,
+						"description": "Source frame and unit scale read from the .fbx header. Shown so you can\nverify auto-detection; it drives the output only when 'Auto-Detect Source'\nis on."
+					},
+					{
+						"name": "IsLoaded",
+						"display_name": "Is Loaded",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"data": false,
+						"readonly": true,
+						"description": "True if a valid 'Path' was selected and the file could be loaded."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGeometry/Source/PluginMain.cpp
+++ b/Plugins/nosGeometry/Source/PluginMain.cpp
@@ -1,0 +1,31 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/PluginAPI.h>
+#include <Nodos/Plugin.hpp>
+#include <Nodos/Plugin.hpp>
+
+NOS_INIT()
+NOS_BEGIN_IMPORT_DEPS()
+NOS_END_IMPORT_DEPS()
+
+namespace nos::geometry
+{
+nosResult RegisterReadFBXTransform(nosNodeFunctions*);
+}
+
+nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outCount, nosNodeFunctions** outFunctions)
+{
+    *outCount = 1;
+    if (!outFunctions)
+        return NOS_RESULT_SUCCESS;
+    return nos::geometry::RegisterReadFBXTransform(outFunctions[0]);
+}
+
+extern "C"
+{
+NOSAPI_ATTR nosResult NOSAPI_CALL nosExportPlugin(nosPluginFunctions* out)
+{
+	out->ExportNodeFunctions = ExportNodeFunctions;
+	return NOS_RESULT_SUCCESS;
+}
+}

--- a/Plugins/nosGeometry/Source/ReadFBXTransform.cpp
+++ b/Plugins/nosGeometry/Source/ReadFBXTransform.cpp
@@ -1,0 +1,407 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <Nodos/Plugin.hpp>
+
+// Framework builtins (nos.fb.vec3d / nos.fb.vec4d)
+#include <Builtins_generated.h>
+// nos.graphics.TransformQ and the CoordinateFrame struct (generated from
+// nos.graphics' Graphics.fbs).
+#include <nosTrack/Coordinates_generated.h>
+// BasisMatrix() / UnitFactor() for the source -> output system change, plus the
+// UNREAL_SYSTEM / GLTF_SYSTEM presets used as detection bases.
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+// Vendored FBX reader
+#include <ofbx.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace nos::geometry
+{
+NOS_REGISTER_NAME(Path)
+NOS_REGISTER_NAME(Object)
+NOS_REGISTER_NAME(OutputFrame)
+NOS_REGISTER_NAME(AutoDetectSource)
+NOS_REGISTER_NAME(SourceFrame)
+NOS_REGISTER_NAME(LocalTransform)
+NOS_REGISTER_NAME(GlobalTransform)
+NOS_REGISTER_NAME(DetectedFrame)
+NOS_REGISTER_NAME(IsLoaded)
+
+using Frame = nos::track::CoordinateFrame;
+
+// Frame-independent decomposition of an FBX object's transform. Rotation is kept
+// as a matrix so it can be re-expressed in whatever CoordinateFrame the user picks
+// without re-reading the file.
+struct RawTransform
+{
+	glm::dvec3 Translation{0.0};
+	glm::dmat3 Rotation{1.0};
+	glm::dvec3 Scale{1.0};
+};
+
+struct ObjectTransforms
+{
+	RawTransform Local;
+	RawTransform Global;
+};
+
+// Decompose an openFBX 4x4 (column-major double[16]) into translation, a
+// normalized rotation matrix, and per-axis scale.
+static RawTransform DecomposeMatrix(ofbx::DMatrix const& m)
+{
+	glm::dmat4 gm(1.0);
+	for (int c = 0; c < 4; ++c)
+		for (int r = 0; r < 4; ++r)
+			gm[c][r] = m.m[c * 4 + r];
+
+	RawTransform out;
+	out.Translation = glm::dvec3(gm[3]);
+	out.Scale = glm::dvec3(glm::length(glm::dvec3(gm[0])),
+						   glm::length(glm::dvec3(gm[1])),
+						   glm::length(glm::dvec3(gm[2])));
+	out.Rotation = glm::dmat3(
+		out.Scale.x != 0.0 ? glm::dvec3(gm[0]) / out.Scale.x : glm::dvec3(1, 0, 0),
+		out.Scale.y != 0.0 ? glm::dvec3(gm[1]) / out.Scale.y : glm::dvec3(0, 1, 0),
+		out.Scale.z != 0.0 ? glm::dvec3(gm[2]) / out.Scale.z : glm::dvec3(0, 0, 1));
+	return out;
+}
+
+// Map an .fbx header's axis system + units onto a CoordinateFrame. The engine's
+// preset bases are Z-up left-handed (Unreal) and Y-up right-handed (glTF), so the
+// up-axis is the deciding signal for the basis; openFBX's own header advises
+// ignoring FrontAxis (unreliable across exporters), so we key off UpAxis only. The
+// preset's unit is replaced with the file's own: FBX UnitScaleFactor is centimeters
+// per unit (default 1.0 => cm), so meters_per_unit = UnitScaleFactor / 100.
+static Frame DetectSystem(ofbx::GlobalSettings const* gs)
+{
+	Frame base = (gs && gs->UpAxis == ofbx::UpVector_AxisZ) ? nos::track::UNREAL_SYSTEM
+															: nos::track::GLTF_SYSTEM;
+	double mpu = 0.01; // FBX default UnitScaleFactor 1.0 (cm)
+	if (gs && gs->UnitScaleFactor > 0.0f)
+		mpu = static_cast<double>(gs->UnitScaleFactor) / 100.0;
+	return Frame(base.up(), base.forward(), base.handedness(), base.euler(), mpu);
+}
+
+// Convert a frame-independent transform into `target`, applying a uniform
+// translation scale. M is a signed axis permutation, so:
+//   translation -> M * t      rotation -> M * R * M^T      scale -> |M| * s
+// The rotation conjugation stays a proper rotation even across a handedness flip
+// (det(M)^2 = 1), so quat_cast is well-defined.
+static nos::track::TransformQ ConvertToTransformQ(RawTransform const& t, glm::dmat3 const& M, double scale)
+{
+	glm::dvec3 outT = M * t.Translation * scale;
+	glm::dmat3 outR = M * t.Rotation * glm::transpose(M);
+
+	glm::dmat3 absM(0.0);
+	for (int c = 0; c < 3; ++c)
+		for (int r = 0; r < 3; ++r)
+			absM[c][r] = std::abs(M[c][r]);
+	glm::dvec3 outS = absM * t.Scale;
+
+	glm::dquat q = glm::normalize(glm::quat_cast(outR));
+	return nos::track::TransformQ(
+		fb::vec3d(outT.x, outT.y, outT.z),
+		fb::vec4d(q.x, q.y, q.z, q.w),
+		fb::vec3d(outS.x, outS.y, outS.z));
+}
+
+struct ReadFBXTransformNode : NodeContext
+{
+	// Combo-box labels in display order and their resolved (raw) transforms.
+	std::vector<std::string> ObjectLabels;
+	std::unordered_map<std::string, ObjectTransforms> Transforms;
+	// Per-node unique name of the string list backing the Object combo box.
+	std::string ComboListName;
+	// Object the user last selected; preferred when (re)loading a file.
+	std::string DesiredSelection;
+
+	// System settings. The effective source is Detected when AutoDetect is on,
+	// otherwise SourceOverride; the result is expressed in OutputFrame. The unit
+	// conversion is derived from the source and output systems' meters_per_unit.
+	Frame OutputFrame = nos::track::UNREAL_SYSTEM;
+	bool AutoDetect = true;
+	Frame SourceOverride = nos::track::GLTF_SYSTEM;
+	// Source system read from the loaded file's header (basis + meters_per_unit).
+	Frame Detected = nos::track::GLTF_SYSTEM;
+	bool Loaded = false;
+
+	// File info is surfaced as a set of short status lines (one slot each) rather than a
+	// single string, so the file, object count, frame and selection update independently.
+	// The set is pushed to the engine only when it actually changes (see FlushStatus).
+	enum class StatusSlot : int { State = 0, File = 1, Objects = 2, Frame = 3, Selected = 4 };
+	std::map<StatusSlot, fb::TNodeStatusMessage> StatusMessages;
+	bool StatusDirty = false;
+
+	void SetStatus(StatusSlot slot, fb::NodeStatusMessageType type, std::string text)
+	{
+		auto it = StatusMessages.find(slot);
+		if (it != StatusMessages.end() && it->second.type == type && it->second.text == text)
+			return; // unchanged - leave the dirty flag alone
+		StatusMessages[slot] = fb::TNodeStatusMessage{ {}, std::move(text), type };
+		StatusDirty = true;
+	}
+
+	void ClearStatus(StatusSlot slot)
+	{
+		if (StatusMessages.erase(slot))
+			StatusDirty = true;
+	}
+
+	// Pushes the message set to the engine only when it changed (map order = display order).
+	void FlushStatus()
+	{
+		if (!StatusDirty)
+			return;
+		std::vector<fb::TNodeStatusMessage> messages;
+		messages.reserve(StatusMessages.size());
+		for (auto& [slot, msg] : StatusMessages)
+			messages.push_back(msg);
+		SetNodeStatusMessages(messages);
+		StatusDirty = false;
+	}
+
+	// System the output is converted from, given the auto-detect toggle.
+	Frame EffectiveSource() const { return AutoDetect ? Detected : SourceOverride; }
+
+	// Reflect the auto-detect toggle in the UI: when on, the manual Source Frame pin
+	// is ignored (the detected system wins), so grey it out as passive.
+	void ApplySourceOrphanState()
+	{
+		SetPinOrphanState(NSN_SourceFrame,
+						  AutoDetect ? fb::PinOrphanStateType::PASSIVE : fb::PinOrphanStateType::ACTIVE,
+						  AutoDetect ? "Ignored while Auto-Detect Source is on" : nullptr);
+	}
+
+	// Initialization lives in OnCreate (not the constructor) because LoadFbx calls
+	// SetPinValue, which the engine broadcasts synchronously back into this node's
+	// OnPinValueChanged. With the SAFE binding the engine has already stored our
+	// context pointer by the time OnCreate runs, so that re-entrant callback sees a
+	// valid `this`. Running it from the constructor would re-enter with a null ctx.
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		ComboListName = "nos.geometry.FBXObjects." + std::string(NodeId);
+		SetPinVisualizer(NSN_Object, {.type = nos::fb::VisualizerType::COMBO_BOX, .name = ComboListName});
+
+		// Restore saved path / selection / system settings.
+		std::string path;
+		if (auto* pins = node->pins())
+			for (auto const* pin : *pins)
+			{
+				if (!pin->data() || !pin->data()->size())
+					continue;
+				auto const* name = pin->name()->c_str();
+				auto const* data = pin->data()->data();
+				if (0 == strcmp(name, "Path"))
+					path = reinterpret_cast<const char*>(data);
+				else if (0 == strcmp(name, "Object"))
+					DesiredSelection = reinterpret_cast<const char*>(data);
+				else if (0 == strcmp(name, "OutputFrame"))
+					OutputFrame = *reinterpret_cast<const Frame*>(data);
+				else if (0 == strcmp(name, "AutoDetectSource"))
+					AutoDetect = *reinterpret_cast<const uint8_t*>(data) != 0;
+				else if (0 == strcmp(name, "SourceFrame"))
+					SourceOverride = *reinterpret_cast<const Frame*>(data);
+			}
+		ApplySourceOrphanState();
+		if (!path.empty())
+			LoadFbx(path);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinValueChanged(nos::Name pinName, uuid const& pinId, nosBuffer value) override
+	{
+		if (pinName == NSN_Path)
+		{
+			LoadFbx(value.Data ? reinterpret_cast<const char*>(value.Data) : "");
+			return;
+		}
+		else if (pinName == NSN_Object)
+		{
+			DesiredSelection = value.Data ? reinterpret_cast<const char*>(value.Data) : "";
+		}
+		else if (pinName == NSN_OutputFrame)
+		{
+			if (value.Data)
+				OutputFrame = *reinterpret_cast<const Frame*>(value.Data);
+		}
+		else if (pinName == NSN_AutoDetectSource)
+		{
+			if (value.Data)
+				AutoDetect = *reinterpret_cast<const uint8_t*>(value.Data) != 0;
+			ApplySourceOrphanState();
+		}
+		else if (pinName == NSN_SourceFrame)
+		{
+			if (value.Data)
+				SourceOverride = *reinterpret_cast<const Frame*>(value.Data);
+		}
+		else
+			return;
+
+		UpdateOutputs(DesiredSelection);
+	}
+
+	void LoadFbx(std::string const& path)
+	{
+		ObjectLabels.clear();
+		Transforms.clear();
+		UpdateStringList(ComboListName, {});
+
+		std::error_code ec;
+		if (path.empty() || !std::filesystem::exists(path, ec))
+		{
+			Finish(false, path.empty() ? "No FBX file selected" : "FBX file not found");
+			return;
+		}
+
+		std::ifstream file(std::filesystem::path(path), std::ios::binary);
+		std::vector<ofbx::u8> content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+		if (content.empty())
+		{
+			Finish(false, "Failed to read FBX file");
+			return;
+		}
+
+		// We only need the scene graph / transforms, so skip the heavy payloads.
+		auto flags = ofbx::LoadFlags::IGNORE_GEOMETRY | ofbx::LoadFlags::IGNORE_BLEND_SHAPES |
+					 ofbx::LoadFlags::IGNORE_TEXTURES | ofbx::LoadFlags::IGNORE_SKIN |
+					 ofbx::LoadFlags::IGNORE_MATERIALS | ofbx::LoadFlags::IGNORE_ANIMATIONS |
+					 ofbx::LoadFlags::IGNORE_VIDEOS | ofbx::LoadFlags::IGNORE_POSES;
+
+		ofbx::IScene* scene = ofbx::load(content.data(), static_cast<int>(content.size()), static_cast<ofbx::u16>(flags));
+		if (!scene)
+		{
+			nosEngine.LogE("ReadFBXTransform: failed to parse '%s': %s", path.c_str(), ofbx::getError());
+			Finish(false, "Failed to parse FBX");
+			return;
+		}
+
+		Detected = DetectSystem(scene->getGlobalSettings());
+
+		std::unordered_set<std::string> usedLabels;
+		int count = scene->getAllObjectCount();
+		ofbx::Object const* const* objects = scene->getAllObjects();
+		for (int i = 0; i < count; ++i)
+		{
+			ofbx::Object const* obj = objects[i];
+			if (!obj || !obj->isNode())
+				continue;
+
+			std::string base = (obj->name[0] != '\0') ? obj->name : "(unnamed)";
+			std::string label = base;
+			for (int suffix = 2; usedLabels.count(label); ++suffix)
+				label = base + " (" + std::to_string(suffix) + ")";
+			usedLabels.insert(label);
+
+			ObjectTransforms t;
+			t.Local = DecomposeMatrix(obj->getLocalTransform());
+			t.Global = DecomposeMatrix(obj->getGlobalTransform());
+
+			Transforms.emplace(label, t);
+			ObjectLabels.push_back(std::move(label));
+		}
+		scene->destroy();
+
+		if (ObjectLabels.empty())
+		{
+			Finish(false, "No objects found in FBX");
+			return;
+		}
+
+		UpdateStringList(ComboListName, ObjectLabels);
+
+		// File info lines: name, object count and the detected authoring frame.
+		SetStatus(StatusSlot::File, fb::NodeStatusMessageType::INFO,
+				  std::filesystem::path(path).filename().string());
+		SetStatus(StatusSlot::Objects, fb::NodeStatusMessageType::INFO,
+				  std::to_string(ObjectLabels.size()) + " object(s)");
+		PublishDetectedFrame();
+
+		// Keep the previous selection if it still exists, otherwise pick the first.
+		std::string selection = Transforms.count(DesiredSelection) ? DesiredSelection : ObjectLabels.front();
+		DesiredSelection = selection;
+		SetPinValue(NSN_Object, selection.c_str());
+		UpdateOutputs(selection);
+
+		Finish(true, "Loaded");
+	}
+
+	void UpdateOutputs(std::string const& selection)
+	{
+		auto it = Transforms.find(selection);
+		if (it == Transforms.end())
+			return;
+
+		const Frame source = EffectiveSource();
+		const glm::dmat3 S_src = nos::track::BasisMatrix(source);
+		const glm::dmat3 S_tgt = nos::track::BasisMatrix(OutputFrame);
+		const glm::dmat3 M = S_tgt * glm::inverse(S_src);
+		const double scale = nos::track::UnitFactor(source, OutputFrame);
+
+		SetPinValue(NSN_LocalTransform, nos::Buffer::From(ConvertToTransformQ(it->second.Local, M, scale)));
+		SetPinValue(NSN_GlobalTransform, nos::Buffer::From(ConvertToTransformQ(it->second.Global, M, scale)));
+
+		// Selected object plus a compact readout of its converted global translation.
+		glm::dvec3 gt = M * it->second.Global.Translation * scale;
+		char buf[160];
+		std::snprintf(buf, sizeof(buf), "%s  T(%.3g, %.3g, %.3g)", selection.c_str(), gt.x, gt.y, gt.z);
+		SetStatus(StatusSlot::Selected, fb::NodeStatusMessageType::INFO, buf);
+		PublishDetectedFrame();
+		FlushStatus();
+	}
+
+	// Surface the detected source system (basis + unit scale), both on the output pin
+	// and as a status line. A note marks whether it is actually driving the conversion.
+	void PublishDetectedFrame()
+	{
+		char buf[96];
+		std::snprintf(buf, sizeof(buf), "%s up, %s, %g m/unit",
+					  nos::track::EnumNameSignedAxis(Detected.up()),
+					  nos::track::EnumNameHandedness(Detected.handedness()),
+					  Detected.meters_per_unit());
+		std::string text = buf;
+		if (!AutoDetect)
+			text += "  (override active)";
+		SetPinValue(NSN_DetectedFrame, text.c_str());
+		SetStatus(StatusSlot::Frame, fb::NodeStatusMessageType::INFO, std::string("Frame: ") + text);
+	}
+
+	void Finish(bool ok, std::string const& message)
+	{
+		Loaded = ok;
+		SetPinValue(NSN_IsLoaded, nos::Buffer::From(Loaded));
+		SetStatus(StatusSlot::State, ok ? fb::NodeStatusMessageType::INFO : fb::NodeStatusMessageType::WARNING,
+				  message);
+		if (!ok)
+		{
+			// No valid file: drop the file-info lines, leave only the State line.
+			ClearStatus(StatusSlot::File);
+			ClearStatus(StatusSlot::Objects);
+			ClearStatus(StatusSlot::Frame);
+			ClearStatus(StatusSlot::Selected);
+		}
+		FlushStatus();
+	}
+};
+
+nosResult RegisterReadFBXTransform(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.geometry.ReadFBXTransform"), ReadFBXTransformNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::geometry

--- a/Plugins/nosGeometry/Types/CoordinateSystemPresets.json
+++ b/Plugins/nosGeometry/Types/CoordinateSystemPresets.json
@@ -1,0 +1,49 @@
+{
+    "name": "nos.geometry.CoordinateSystemPresets",
+    "values": [
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "Unreal"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "OpenGL-glTF"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "NegY", "forward": "PosZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "OpenCV-COLMAP"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "PosZ", "handedness": "LeftHanded", "euler": { "order": "ZXY", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Unity"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "Maya"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Houdini"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "PosY", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "3dsMax"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "NegY", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Blender"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "value_name": "Custom"
+        }
+    ]
+}

--- a/Plugins/nosGraphics/Graphics.nosplugin
+++ b/Plugins/nosGraphics/Graphics.nosplugin
@@ -1,0 +1,35 @@
+{
+	"info": {
+		"id": {
+			"name": "nos.graphics",
+			"version": "0.5.0"
+		},
+		"description": "Types & Nodes for graphics operations.",
+		"display_name": "Graphics",
+		"category": "Graphics",
+		"dependencies": [
+			{
+				"name": "nos.sys.vulkan",
+				"version": "8.0"
+			},
+			{
+				"name": "nos.track",
+				"version": "3.0"
+			},
+			{
+				"name": "nos.reflect",
+				"version": "3.0"
+			},
+			{
+				"name": "nos.math",
+				"version": "2.0"
+			}
+		]
+	},
+	"named_values": [
+		"Types/CoordinateSystemPresets.json"
+	],
+	"binary_path": "Binaries/nosGraphics",
+	"sdk_version": "41.0",
+	"schema_version": "1.4-v1"
+}

--- a/Plugins/nosGraphics/Nodes/BillboardMask.nosnode
+++ b/Plugins/nosGraphics/Nodes/BillboardMask.nosnode
@@ -1,0 +1,104 @@
+{
+	"nodes": [
+		{
+			"class_name": "BillboardMask",
+			"menu_info": {
+				"category": "Rendering",
+				"display_name": "Billboard Mask"
+			},
+			"node": {
+				"description": "Renders a camera-facing billboard mask into a color target and depth buffer.",
+				"contents_type": "Job",
+				"pins": [
+					{
+						"name": "Position",
+						"type_name": "nos.fb.vec3",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "World-space position of the billboard base center."
+					},
+					{
+						"name": "InDepth",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Optional D32 depth texture to reuse when ReadInDepth is enabled.",
+						"data": {
+							"format": "D32_SFLOAT"
+						}
+					},
+					{
+						"name": "ReadInDepth",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Uses InDepth as the output depth buffer instead of creating a new one.",
+						"data": true
+					},
+					{
+						"name": "Size",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Billboard size in world units as width and height.",
+						"data": {
+							"x": 100.0,
+							"y": 100.0
+						}
+					},
+					{
+						"name": "ShadowDepth",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Shadow extrusion depth in world units below the billboard.",
+						"data": 50.0
+					},
+					{
+						"name": "GroundLevel",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "World-space vertical coordinate of the ground plane.",
+						"data": 0.0
+					},
+					{
+						"name": "RenderView",
+						"type_name": "nos.graphics.RenderView",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Render view used to orient the billboard and build its matrices."
+					},
+					{
+						"name": "Resolution",
+						"type_name": "nos.fb.vec2u",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Output resolution for the generated render target and depth buffer.",
+						"data": {
+							"x": 1920,
+							"y": 1080
+						}
+					},
+					{
+						"name": "OutRenderTarget",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Mask texture rendered by the billboard pass."
+					},
+					{
+						"name": "OutDepth",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Depth texture written by the pass or forwarded from InDepth.",
+						"data": {
+							"format": "D32_SFLOAT"
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/BillboardPositions.nosnode
+++ b/Plugins/nosGraphics/Nodes/BillboardPositions.nosnode
@@ -1,0 +1,75 @@
+{
+	"nodes": [
+		{
+			"class_name": "BillboardPositions",
+			"menu_info": {
+				"category": "Rendering",
+				"display_name": "Billboard Positions"
+			},
+			"node": {
+				"description": "Computes the four world-space corners of a camera-facing billboard.",
+				"contents_type": "Job",
+				"pins": [
+					{
+						"name": "Position",
+						"type_name": "nos.fb.vec3",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "World-space position of the billboard base center."
+					},
+					{
+						"name": "Width",
+						"type_name": "float",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Billboard width in world units.",
+						"data": 100.0
+					},
+					{
+						"name": "Height",
+						"type_name": "float",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Billboard height in world units, measured upward from Position.",
+						"data": 100.0
+					},
+					{
+						"name": "RenderView",
+						"type_name": "nos.graphics.RenderView",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Render view used to orient the billboard toward the camera."
+					},
+					{
+						"name": "BottomLeft",
+						"type_name": "nos.fb.vec3",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "World-space position of the billboard's bottom-left corner."
+					},
+					{
+						"name": "BottomRight",
+						"type_name": "nos.fb.vec3",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "World-space position of the billboard's bottom-right corner."
+					},
+					{
+						"name": "TopLeft",
+						"type_name": "nos.fb.vec3",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "World-space position of the billboard's top-left corner."
+					},
+					{
+						"name": "TopRight",
+						"type_name": "nos.fb.vec3",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "World-space position of the billboard's top-right corner."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/CameraGuide.nosnode
+++ b/Plugins/nosGraphics/Nodes/CameraGuide.nosnode
@@ -1,0 +1,82 @@
+{
+	"nodes": [
+		{
+			"class_name": "CameraGuide",
+			"menu_info": {
+				"category": "Graphics|Coordinate System",
+				"display_name": "Camera Guide"
+			},
+			"node": {
+				"class_name": "CameraGuide",
+				"contents_type": "Job",
+				"description": "Passes Source straight through to Out and reports, in its node status, the\negocentric motion needed to bring Source roughly onto Target.\nTranslation is given along Source's local axes (forward/back, right/left,\nup/down) in the chosen coordinate Frame.\nRotation is in camera-operator terms taken against the Frame's vertical:\npan rotates about world up, tilt changes elevation, roll changes bank about\nforward. Roll CW/CCW is as seen by an operator looking along the camera's\nforward axis (through the lens), so looking around (pan + tilt) yields no roll.\nBoth Tracks' Euler rotations are decoded with the same Frame, so no cross-frame\nmismatch is possible. Components below the Position/Angle tolerances are omitted.",
+				"pins": [
+					{
+						"name": "Source",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Track to align. Forwarded unchanged to Out."
+					},
+					{
+						"name": "Target",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Track that Source should be brought onto."
+					},
+					{
+						"name": "Frame",
+						"display_name": "Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.graphics.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system both Tracks are authored in. Sets which axes map to forward/right/up and the euler encoding both rotations are decoded with."
+					},
+					{
+						"name": "PositionTolerance",
+						"display_name": "Position Tolerance",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.01,
+						"description": "Per-axis translation magnitude below which a direction is considered aligned and omitted from the status."
+					},
+					{
+						"name": "AngleTolerance",
+						"display_name": "Angle Tolerance",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0.5,
+						"description": "Rotation magnitude in degrees below which an axis is considered aligned and omitted from the status."
+					},
+					{
+						"name": "Out",
+						"type_name": "nos.track.Track",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Source, forwarded unchanged."
+					},
+					{
+						"name": "Guidance",
+						"type_name": "nos.track.TransformGuidance",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Structured correction (alignment, forward/right/up, pan/tilt/roll). Compose display text downstream."
+					},
+					{
+						"name": "GuidanceText",
+						"display_name": "Guidance Text",
+						"type_name": "string",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Prebuilt status text, for a downstream text renderer."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/ConvertCoordinateFrame.nosnode
+++ b/Plugins/nosGraphics/Nodes/ConvertCoordinateFrame.nosnode
@@ -1,0 +1,50 @@
+{
+	"nodes": [
+		{
+			"class_name": "ConvertCoordinateFrame",
+			"menu_info": {
+				"category": "Graphics|Coordinate System",
+				"display_name": "Convert Coordinate Frame"
+			},
+			"node": {
+				"class_name": "ConvertCoordinateFrame",
+				"contents_type": "Job",
+				"description": "Converts a TransformQ between coordinate systems.\nThe Source and Target systems select axis assignments, handedness and units.\nPosition: basis-changed (Source -> Target), then scaled by the ratio of the two\nsystems' meters_per_unit (e.g. cm -> m yields 0.01).\nRotation: the quaternion is conjugated by the basis-change matrix, so no Euler convention is involved.\nScale: axis factors are reordered to follow the basis change.",
+				"pins": [
+					{
+						"name": "In",
+						"type_name": "nos.track.TransformQ",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "SourceFrame",
+						"display_name": "Source Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.graphics.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system convention of the input TransformQ (its euler encoding is unused on this quaternion node)."
+					},
+					{
+						"name": "TargetFrame",
+						"display_name": "Target Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.graphics.CoordinateSystemPresets" },
+						"data": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+						"description": "Coordinate system convention of the output TransformQ (its euler encoding is unused on this quaternion node)."
+					},
+					{
+						"name": "Out",
+						"type_name": "nos.track.TransformQ",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/HomographySolver.nosnode
+++ b/Plugins/nosGraphics/Nodes/HomographySolver.nosnode
@@ -1,0 +1,89 @@
+{
+	"nodes": [
+		{
+			"class_name": "HomographySolver",
+			"menu_info": {
+				"category": "Graphics",
+				"display_name": "Homography Solver"
+			},
+			"node": {
+				"class_name": "HomographySolver",
+				"contents_type": "Job",
+				"description": "Computes a 3x3 homography matrix from 4 point correspondences using the DLT algorithm.",
+				"pins": [
+					{
+						"name": "Source 1",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "First point in the source plane.",
+						"data": { "x": 0.0, "y": 0.0 }
+					},
+					{
+						"name": "Source 2",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Second point in the source plane.",
+						"data": { "x": 1.0, "y": 0.0 }
+					},
+					{
+						"name": "Source 3",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Third point in the source plane.",
+						"data": { "x": 1.0, "y": 1.0 }
+					},
+					{
+						"name": "Source 4",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Fourth point in the source plane.",
+						"data": { "x": 0.0, "y": 1.0 }
+					},
+					{
+						"name": "Target 1",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "First point in the target plane, corresponding to Source 1.",
+						"data": { "x": 0.0, "y": 0.0 }
+					},
+					{
+						"name": "Target 2",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Second point in the target plane, corresponding to Source 2.",
+						"data": { "x": 1.0, "y": 0.0 }
+					},
+					{
+						"name": "Target 3",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Third point in the target plane, corresponding to Source 3.",
+						"data": { "x": 1.0, "y": 1.0 }
+					},
+					{
+						"name": "Target 4",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Fourth point in the target plane, corresponding to Source 4.",
+						"data": { "x": 0.0, "y": 1.0 }
+					},
+					{
+						"name": "Homography",
+						"type_name": "nos.fb.mat3",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "3x3 homography matrix that maps source points to target points in homogeneous coordinates."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/NormalizedDepthToDepthBuffer.nosnode
+++ b/Plugins/nosGraphics/Nodes/NormalizedDepthToDepthBuffer.nosnode
@@ -1,0 +1,49 @@
+{
+	"nodes": [
+		{
+			"class_name": "NormalizedDepthToDepthBuffer",
+			"menu_info": {
+				"category": "Rendering|Advanced",
+				"display_name": "Convert Normalized Depth To Depth Buffer"
+			},
+			"node": {
+				"description": "Converts a normalized depth texture into a D32 depth buffer using the render view clip planes.",
+				"contents_type": "Job",
+				"pins": [
+					{
+						"name": "InDepth",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Input texture whose red channel stores normalized depth values."
+					},
+					{
+						"name": "RenderView",
+						"type_name": "nos.graphics.RenderView",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Render view that provides the near and far clip planes for reconstruction."
+					},
+					{
+						"name": "Scale",
+						"type_name": "float",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Multiplier applied to the sampled normalized depth before reconstruction.",
+						"data": 1.0
+					},
+					{
+						"name": "OutDepth",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Output D32 depth buffer texture.",
+						"data": {
+							"format": "D32_SFLOAT"
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/Project.nosnode
+++ b/Plugins/nosGraphics/Nodes/Project.nosnode
@@ -1,0 +1,1197 @@
+{ "nodes": [
+    {
+      "class_name": "nos.graphics.Project",
+			"menu_info": {
+				"category": "Graphics|Math",
+				"display_name": "Project"
+			},
+      "node": {
+        "id": "d54e9cb5-27a8-4f0d-8222-b60eec326834",
+        "name": "Project",
+        "class_name": "nos.graphics.Project",
+        "pins": [
+          {
+            "id": "3e916e05-e6ec-448d-9b72-c2f515a5ce05",
+            "name": "Model",
+            "type_name": "nos.fb.mat4",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "99d5d7a2-8484-4b81-8660-d73da266e5be" },
+            "display_name": "Model"
+          },
+          {
+            "id": "094747c5-3dc0-4643-9cbc-52bba21a01eb",
+            "name": "View",
+            "type_name": "nos.fb.mat4",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": 59.655338, "y": -55.744328, "z": 469.072449, "w": 1.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "44cad3c1-94b3-4597-8c8a-a23e0dd36b14" },
+            "display_name": "View"
+          },
+          {
+            "id": "a95571c2-97a5-4318-9029-dc9822085330",
+            "name": "B",
+            "type_name": "nos.fb.mat4",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "1e4ef97e-5da5-4070-998e-567feb545796" }
+          },
+          {
+            "id": "1c100948-846f-41b6-b7b9-868c60b5898e",
+            "name": "Output",
+            "type_name": "nos.fb.vec2",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_ONLY",
+            "visualizer": {
+            },
+            "data": { "x": 0.0, "y": 0.0 },
+            "def": { "x": 0.0, "y": 0.0 },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "0382b3f8-8796-45e4-a0d6-67db2b4eb4c5" }
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "440c6c78-d299-40fa-b926-a9b9071a70e4",
+              "name": "Break (1)",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "8380704f-fdaf-44bd-aabe-6f1cea9936d1",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -1.52512, "y": 0.034559, "z": -0.207524, "w": -0.207522 }, "y": { "x": -0.324149, "y": -0.162603, "z": 0.9764, "w": 0.976391 }, "z": { "x": 0.0, "y": -2.767091, "z": -0.059968, "w": -0.059968 }, "w": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "f17fd945-2f2b-466f-a8d5-891cd7cf0b3b",
+                  "name": "x",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -1.52512, "y": 0.034559, "z": -0.207524, "w": -0.207522 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "19d3e1f0-f476-451d-a10c-3be2edbbf606",
+                  "name": "y",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -0.324149, "y": -0.162603, "z": 0.9764, "w": 0.976391 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "afbef332-3981-4148-9eb0-6aba6bdcb9c3",
+                  "name": "z",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": -2.767091, "z": -0.059968, "w": -0.059968 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "793325a5-faa8-4be4-b918-c1927413334f",
+                  "name": "w",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1356.0, "y": -86.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "meta_data_map": [
+                { "key": "PinVisibility", "value": "ShowAll" }
+              ],
+              "display_name": "Break nos.fb.mat4",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "53226bc5-3615-43e0-9583-7b39ec5af458",
+              "name": "Eval (1)",
+              "class_name": "nos.math.Eval",
+              "pins": [
+                {
+                  "id": "203f5cf6-d70a-42e7-b2ad-4676a6b76cf3",
+                  "name": "Expression",
+                  "type_name": "string",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": "A * 0.5 + 0.5",
+                  "def": "",
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "554347d6-a148-45ef-97dc-00c1f89e484f",
+                  "name": "Result",
+                  "type_name": "double",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.542191866785,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "46780548-bf98-4b72-ba5f-16acfa18e486",
+                  "name": "Show_Expression",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": true,
+                  "def": true,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Show Expression In Node"
+                },
+                {
+                  "id": "a022174c-e62b-4a66-8044-a19693c4a83d",
+                  "name": "A",
+                  "type_name": "double",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.084383733571,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "152328fa-f77c-4415-8d13-f4d210803ad0",
+                  "name": "B",
+                  "type_name": "double",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2573.0, "y": -40.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "status_messages": [
+                { "text": "A * 0.5 + 0.5" }
+              ],
+              "description": "Evaluates a string expression",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "ad68df00-94d1-4a77-aa52-695412cd5fdf",
+              "name": "Eval",
+              "class_name": "nos.math.Eval",
+              "pins": [
+                {
+                  "id": "8245eedc-c55c-4265-9e98-2ec78e74b95b",
+                  "name": "Expression",
+                  "type_name": "string",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": "A * 0.5 + 0.5",
+                  "def": "",
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "2d9c0ee1-8253-4dd4-9d99-0d0a22691a67",
+                  "name": "Result",
+                  "type_name": "double",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.342610880733,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "b950c859-b2a4-42b6-bd33-668a5c7a5c2f",
+                  "name": "Show_Expression",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": true,
+                  "def": true,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Show Expression In Node"
+                },
+                {
+                  "id": "f25f8b22-1afa-4874-a3e6-34df86bd65f8",
+                  "name": "A",
+                  "type_name": "double",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -0.314778238535,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ea04e517-8b49-481a-aa8a-5e5cd6df6e6d",
+                  "name": "B",
+                  "type_name": "double",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2569.0, "y": -140.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "status_messages": [
+                { "text": "A * 0.5 + 0.5" }
+              ],
+              "description": "Evaluates a string expression",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "dea8e9bd-3dc8-4316-ac40-4b11a4df5c3a",
+              "name": "double to float",
+              "class_name": "cast.double-float",
+              "pins": [
+                {
+                  "id": "5992ee27-14ab-4807-bcc1-a3c173ff10ab",
+                  "name": "double",
+                  "type_name": "double",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.342610880733,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "0b6eff88-2e2d-45c3-a5bc-11cd09db0aea",
+                  "name": "float",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.342611,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2726.0, "y": -138.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "f18f2269-40a4-4121-b2bf-8148f930574d",
+              "name": "Arithmetic (2)",
+              "class_name": "nos.reflect.Arithmetic",
+              "pins": [
+                {
+                  "id": "89999773-1814-477b-a136-8bfec1692316",
+                  "name": "Output",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.084384,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!resource"
+                },
+                {
+                  "id": "7e0086c8-b375-4215-8374-bef83592ec3b",
+                  "name": "A",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 45.830833,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!resource"
+                },
+                {
+                  "id": "f9a8cc6f-ae80-44d5-a3f8-1f7ca6abbeed",
+                  "name": "B",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 543.124023,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!resource"
+                }
+              ],
+              "pos": { "x": 1806.0, "y": 4.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Div",
+              "template_parameters": [
+                { "name": "Operator", "type_name": "nos.reflect.BinaryOperator", "value": "DIV" },
+                { "name": "Type", "type_name": "string", "value": "float" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "80f02610-ba8a-43d6-a998-93224f4ca461",
+              "name": "Transform (1)",
+              "class_name": "nos.math.Transform",
+              "pins": [
+                {
+                  "id": "88c655d4-3e9a-42ec-9a26-727172634a90",
+                  "name": "A",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": -109.649261, "y": -16.533016, "z": 543.124023, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "MV"
+                },
+                {
+                  "id": "411ae940-8fe2-4ac7-ace9-c90f74426d79",
+                  "name": "B",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Proj"
+                },
+                {
+                  "id": "c5499b74-227a-4acf-85e4-cf6eaa692f51",
+                  "name": "Result",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -1.52512, "y": 0.034559, "z": -0.207524, "w": -0.207522 }, "y": { "x": -0.324149, "y": -0.162603, "z": 0.9764, "w": 0.976391 }, "z": { "x": 0.0, "y": -2.767091, "z": -0.059968, "w": -0.059968 }, "w": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1116.0, "y": -52.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Projected",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "4508d4ad-40a5-4da3-b6e8-3381cf1f72ac",
+              "name": "Transform (2)",
+              "class_name": "nos.math.Transform",
+              "pins": [
+                {
+                  "id": "8a8b34e2-e413-4b0d-84da-3315aafd0c46",
+                  "name": "A",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Model"
+                },
+                {
+                  "id": "af8aa3d2-886c-4c00-b9e6-a328e0f1abad",
+                  "name": "B",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": 59.655338, "y": -55.744328, "z": 469.072449, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "View"
+                },
+                {
+                  "id": "0e5e2e47-93d1-4c90-9264-2a6cd56a3ac3",
+                  "name": "Result",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": -109.649261, "y": -16.533016, "z": 543.124023, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 880.0, "y": -97.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "ToView",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "b679e4d8-0aac-429c-84db-73e5307ceb81",
+              "name": "Model",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "064a9284-14e1-4629-931e-635c687ea4ad",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Model"
+                },
+                {
+                  "id": "99d5d7a2-8484-4b81-8660-d73da266e5be",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "referred_by": [
+                    "3e916e05-e6ec-448d-9b72-c2f515a5ce05"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "Model"
+                }
+              ],
+              "pos": { "x": 680.0, "y": -52.866665 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "af49cd88-a0cf-42c1-9bc4-7d6516586ddc",
+              "name": "Break (4)",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "059886fe-694b-434c-8fdf-460ed29d7bb7",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "6752214b-38a8-4dff-9c4c-38a3758381c3",
+                  "name": "x",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -170.963623,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "6a1646e8-237e-4ac9-a59b-5f4ce54f510e",
+                  "name": "y",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 45.830833,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "77885544-1ce4-4fba-8bc4-faa936f5ec80",
+                  "name": "z",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 543.02948,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "eb0a2c0b-c5ce-40f9-96ec-d5f086d57ba7",
+                  "name": "w",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 543.124023,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1580.0, "y": -52.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Break nos.fb.vec4",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "85d4e181-d869-4ae0-87df-8fc27eed88a8",
+              "name": "Break (5)",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "c1856c18-dfb4-47c5-a251-97ba2719c91b",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -0.314778, "y": 0.084384 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "2ec5d750-06b7-4f4e-8b6a-8786a34aaad9",
+                  "name": "x",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -0.314778,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "d8262202-a1ec-40b5-be38-2fc0d5b2b05c",
+                  "name": "y",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.084384,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2216.0, "y": -84.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Break nos.fb.vec2",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "5866c495-f674-485a-a9f1-9b65cce32e88",
+              "name": "Arithmetic (1)",
+              "class_name": "nos.reflect.Arithmetic",
+              "pins": [
+                {
+                  "id": "e4b9847a-6b2d-4274-8a50-e927237a5154",
+                  "name": "Output",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": -0.314778,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!resource"
+                },
+                {
+                  "id": "a4554007-87f0-4b83-9470-741efdb00f3c",
+                  "name": "A",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -170.963623,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!resource"
+                },
+                {
+                  "id": "ecdb5b98-fa83-4024-ae3b-98da777ab8a8",
+                  "name": "B",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 543.124023,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!resource"
+                }
+              ],
+              "pos": { "x": 1804.0, "y": -97.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Div",
+              "template_parameters": [
+                { "name": "Operator", "type_name": "nos.reflect.BinaryOperator", "value": "DIV" },
+                { "name": "Type", "type_name": "string", "value": "float" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "6ffa7f1e-76b7-4af6-bd74-505d1ce30f70",
+              "name": "float to double (1)",
+              "class_name": "cast.float-double",
+              "pins": [
+                {
+                  "id": "da50619a-567e-433f-b97c-078ecc013133",
+                  "name": "float",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.084384,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "5f027d9e-2ad4-457f-9951-7bdf451c108f",
+                  "name": "double",
+                  "type_name": "double",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.084383733571,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2416.0, "y": -55.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "a696c436-a3c6-410f-8bd1-a3784d2f9109",
+              "name": "double to float (1)",
+              "class_name": "cast.double-float",
+              "pins": [
+                {
+                  "id": "d72fe3a3-bcd5-46ab-abb5-fbba5eb6dd8b",
+                  "name": "double",
+                  "type_name": "double",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.542191866785,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "50d40805-af23-40a1-9511-700a240f67cc",
+                  "name": "float",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": 0.542192,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2732.0, "y": -33.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "a2301bf2-07c5-4d07-b991-e708a692d421",
+              "name": "float to double",
+              "class_name": "cast.float-double",
+              "pins": [
+                {
+                  "id": "385c3a32-3808-487a-9b3c-e62f237f2706",
+                  "name": "float",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -0.314778,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "cf17cab9-212f-4586-93ab-6864a061dbc6",
+                  "name": "double",
+                  "type_name": "double",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": -0.314778238535,
+                  "def": 0.0,
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2414.0, "y": -109.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "ac8193c4-3745-4fd2-b709-df99700659ab",
+              "name": "Make (4)",
+              "class_name": "nos.reflect.MakeDynamic",
+              "pins": [
+                {
+                  "id": "1165b2b9-1727-4484-aa29-0bda4be7a730",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -0.314778, "y": 0.084384 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "f3a7604e-d6ae-4331-9a4b-dcba141c198a",
+                  "name": "x",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -0.314778,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "6c00d894-6f57-4344-b6b9-52fa8ac1a278",
+                  "name": "y",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.084384,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1976.0, "y": -84.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "template_parameters": [
+                { "name": "Type", "type_name": "string", "value": "nos.fb.vec2" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "a64bc872-5f86-4c20-af3a-b224d17df114",
+              "name": "Make (3)",
+              "class_name": "nos.reflect.MakeDynamic",
+              "pins": [
+                {
+                  "id": "f954227b-d928-46e3-9f51-b2361623677e",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.342611, "y": 0.542192 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "UV",
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "161d567c-417f-4fb2-a1f9-516fca7290e8",
+                  "name": "x",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.342611,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "f963eeb1-f64e-404a-8a5f-605c12211ea6",
+                  "name": "y",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.542192,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 2928.0, "y": -113.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "template_parameters": [
+                { "name": "Type", "type_name": "string", "value": "nos.fb.vec2" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "4929e884-a612-481a-b095-37098f4ca846",
+              "name": "View",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "69758a77-5a91-471d-ad1d-1e23be0584b5",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": 59.655338, "y": -55.744328, "z": 469.072449, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "View"
+                },
+                {
+                  "id": "44cad3c1-94b3-4597-8c8a-a23e0dd36b14",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": 59.655338, "y": -55.744328, "z": 469.072449, "w": 1.0 } },
+                  "referred_by": [
+                    "094747c5-3dc0-4643-9cbc-52bba21a01eb"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "View"
+                }
+              ],
+              "pos": { "x": 680.0, "y": 22.133335 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "a84b079f-ff37-442a-9e15-98de1e3a477c",
+              "name": "B",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "60a25705-a262-41ae-a496-3a65ae881500",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "1e4ef97e-5da5-4070-998e-567feb545796",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "referred_by": [
+                    "a95571c2-97a5-4318-9029-dc9822085330"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 664.0, "y": 87.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Projection",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "2927cb2e-5dd5-4c00-bab0-6fc6bab6084d",
+              "name": "Output",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "6a3d6695-906e-4b7b-b3d7-7680e22651d7",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.342611, "y": 0.542192 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "0382b3f8-8796-45e4-a0d6-67db2b4eb4c5",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0 },
+                  "referred_by": [
+                    "1c100948-846f-41b6-b7b9-868c60b5898e"
+                  ],
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 3177.0, "y": -110.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "UV",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "comments": [
+            {
+              "id": "4834ea22-e551-46c4-88dd-d2feffef4f0a",
+              "name": "Comment",
+              "hint": "Hint",
+              "content": "Project local point to clip space",
+              "pos": { "x": 1002.0, "y": -104.0 },
+              "size": { "x": 419.0, "y": 180.0 },
+              "bg_color": { "x": 0.342587, "y": 1.0, "z": 0.278761, "w": 0.3 }
+            },
+            {
+              "id": "45f3d3db-32db-42b5-8965-f5b74cd09335",
+              "name": "Comment (1)",
+              "hint": "Hint",
+              "content": "Perspective divide",
+              "pos": { "x": 1660.0, "y": -76.0 },
+              "size": { "x": 829.0, "y": 236.0 },
+              "bg_color": { "x": 0.861938, "y": 0.889381, "z": 0.114124, "w": 0.3 }
+            },
+            {
+              "id": "1bfdf0a7-d6ec-4cba-91eb-07092b2d363b",
+              "name": "Comment (2)",
+              "hint": "Hint",
+              "content": "Convert NDC to UV",
+              "pos": { "x": 2567.0, "y": -125.0 },
+              "size": { "x": 919.0, "y": 224.0 },
+              "bg_color": { "x": 0.99115, "y": 0.39032, "z": 0.39032, "w": 0.3 }
+            }
+          ], "connections": [
+            { "from": "c5499b74-227a-4acf-85e4-cf6eaa692f51", "to": "8380704f-fdaf-44bd-aabe-6f1cea9936d1", "id": "ebe8baa4-b80e-40ce-a718-3a6e69998a70" },
+            { "from": "cf17cab9-212f-4586-93ab-6864a061dbc6", "to": "f25f8b22-1afa-4874-a3e6-34df86bd65f8", "id": "da1b66d5-ccae-49cb-9382-a3f71d971a6d" },
+            { "from": "6752214b-38a8-4dff-9c4c-38a3758381c3", "to": "a4554007-87f0-4b83-9470-741efdb00f3c", "id": "cda36beb-dc68-4c0a-acfc-985bb6b00b96" },
+            { "from": "6a1646e8-237e-4ac9-a59b-5f4ce54f510e", "to": "7e0086c8-b375-4215-8374-bef83592ec3b", "id": "5154d83f-19ee-42a7-98d0-246750731747" },
+            { "from": "0b6eff88-2e2d-45c3-a5bc-11cd09db0aea", "to": "161d567c-417f-4fb2-a1f9-516fca7290e8", "id": "f57471df-208b-4f6d-b980-7045e004bf05" },
+            { "from": "2ec5d750-06b7-4f4e-8b6a-8786a34aaad9", "to": "385c3a32-3808-487a-9b3c-e62f237f2706", "id": "ccf12567-56cf-40d1-bf86-c40ed8bf619b" },
+            { "from": "793325a5-faa8-4be4-b918-c1927413334f", "to": "059886fe-694b-434c-8fdf-460ed29d7bb7", "id": "7c564712-a519-4c92-a3b6-0d4d0c37487b" },
+            { "from": "554347d6-a148-45ef-97dc-00c1f89e484f", "to": "d72fe3a3-bcd5-46ab-abb5-fbba5eb6dd8b", "id": "87e852e9-c2c2-451e-8114-e6cdd2c48081" },
+            { "from": "5f027d9e-2ad4-457f-9951-7bdf451c108f", "to": "a022174c-e62b-4a66-8044-a19693c4a83d", "id": "f1168d2b-70fa-4b52-9d5c-c997e912ed49" },
+            { "from": "eb0a2c0b-c5ce-40f9-96ec-d5f086d57ba7", "to": "ecdb5b98-fa83-4024-ae3b-98da777ab8a8", "id": "cb82b9d8-48fe-4a42-a05f-240d783b44f1" },
+            { "from": "2d9c0ee1-8253-4dd4-9d99-0d0a22691a67", "to": "5992ee27-14ab-4807-bcc1-a3c173ff10ab", "id": "6b12d024-b031-4c8b-85d5-4bda2042a3f8" },
+            { "from": "d8262202-a1ec-40b5-be38-2fc0d5b2b05c", "to": "da50619a-567e-433f-b97c-078ecc013133", "id": "a5d067db-0386-4418-98fc-c33ed9a1d398" },
+            { "from": "eb0a2c0b-c5ce-40f9-96ec-d5f086d57ba7", "to": "f9a8cc6f-ae80-44d5-a3f8-1f7ca6abbeed", "id": "2cf464b5-aae1-4931-8c52-91a219ce1ee1" },
+            { "from": "0e5e2e47-93d1-4c90-9264-2a6cd56a3ac3", "to": "88c655d4-3e9a-42ec-9a26-727172634a90", "id": "97a9a804-6521-4a26-8242-177d5c46a91d" },
+            { "from": "89999773-1814-477b-a136-8bfec1692316", "to": "6c00d894-6f57-4344-b6b9-52fa8ac1a278", "id": "9b24c48c-d1c3-4f3f-8240-28a7d65c911c" },
+            { "from": "1165b2b9-1727-4484-aa29-0bda4be7a730", "to": "c1856c18-dfb4-47c5-a251-97ba2719c91b", "id": "6a5ffde1-f995-400f-bd15-8e8a0cca64c9" },
+            { "from": "e4b9847a-6b2d-4274-8a50-e927237a5154", "to": "f3a7604e-d6ae-4331-9a4b-dcba141c198a", "id": "8ace9af0-9eb5-419f-9c34-5a78ca186ced" },
+            { "from": "50d40805-af23-40a1-9511-700a240f67cc", "to": "f963eeb1-f64e-404a-8a5f-605c12211ea6", "id": "6435e884-376c-4b53-9a40-5c5d5928258a" },
+            { "from": "064a9284-14e1-4629-931e-635c687ea4ad", "to": "8a8b34e2-e413-4b0d-84da-3315aafd0c46", "id": "07b6172e-d893-4b59-a606-b31a2feff65b" },
+            { "from": "69758a77-5a91-471d-ad1d-1e23be0584b5", "to": "af8aa3d2-886c-4c00-b9e6-a328e0f1abad", "id": "3cfaf74f-f7d3-4547-aad5-1a882baf413b" },
+            { "from": "60a25705-a262-41ae-a496-3a65ae881500", "to": "411ae940-8fe2-4ac7-ace9-c90f74426d79", "id": "af5a5204-f16a-46f0-b8a0-9071e4a01184" },
+            { "from": "f954227b-d928-46e3-9f51-b2361623677e", "to": "6a3d6695-906e-4b7b-b3d7-7680e22651d7", "id": "351eaedd-0f28-49a7-8bd4-786d2a59b21e" }
+          ] },
+        "function_category": "Default Node",
+        "plugin_version": { "major": 0, "minor": 4, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosGraphics/Nodes/TrackToTransformQ.nosnode
+++ b/Plugins/nosGraphics/Nodes/TrackToTransformQ.nosnode
@@ -1,0 +1,42 @@
+{
+	"nodes": [
+		{
+			"class_name": "TrackToTransformQ",
+			"menu_info": {
+				"category": "Graphics|Coordinate System",
+				"display_name": "Track To TransformQ"
+			},
+			"node": {
+				"class_name": "TrackToTransformQ",
+				"contents_type": "Job",
+				"description": "Converts a Track's location and Euler rotation into a TransformQ.\nThe rotation is decoded per Encoding and emitted as a quaternion. No frame\nconversion is performed: the output is expressed in the same frame the Track is\nauthored in. Track carries no scale, so the output scale is identity.",
+				"pins": [
+					{
+						"name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Track whose location and rotation are converted."
+					},
+					{
+						"name": "Frame",
+						"display_name": "Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.graphics.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system the Track is authored in; its euler encoding decodes the rotation. No frame conversion is performed."
+					},
+					{
+						"name": "Out",
+						"type_name": "nos.track.TransformQ",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+						"description": "Track pose expressed as a quaternion TransformQ."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/TrackToView.nosnode
+++ b/Plugins/nosGraphics/Nodes/TrackToView.nosnode
@@ -1,0 +1,39 @@
+{
+	"nodes": [
+		{
+			"class_name": "TrackToView",
+			"menu_info": {
+				"category": "Rendering",
+				"display_name": "Track To View"
+			},
+			"node": {
+				"description": "Builds a RenderView from tracked camera data and clip planes.",
+				"contents_type": "Job",
+				"pins": [
+					{
+						"name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Tracked camera data used to derive the view and perspective projection."
+					},
+					{
+						"name": "Clip",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Near and far clip planes for the generated projection.",
+						"data": {"x": 0.1, "y": 10000.0}
+					},
+					{
+						"name": "View",
+						"type_name": "nos.graphics.RenderView",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "Render view built from the track transform, sensor settings, and clip planes."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosGraphics/Nodes/TranslationMatrix.nosnode
+++ b/Plugins/nosGraphics/Nodes/TranslationMatrix.nosnode
@@ -1,0 +1,295 @@
+{ "nodes": [
+    {
+      "class_name": "nos.graphics.TranslationMatrix",
+			"menu_info": {
+				"category": "Graphics|Math",
+				"display_name": "Make Translation Matrix"
+			},
+      "node": {
+        "id": "9a6da894-346d-4e31-a827-71dc0b02c74a",
+        "name": "MakeTranslationMatrix",
+        "class_name": "nos.graphics.TranslationMatrix",
+        "pins": [
+          {
+            "id": "3397e8ac-f446-47c4-8061-45c1d11b14f6",
+            "name": "Matrix",
+            "type_name": "nos.fb.mat4",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_ONLY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "6f2ec7d3-a17b-4f85-9b20-f2f1a23b2195" }
+          },
+          {
+            "id": "0e3b701c-f197-428c-8043-7af3bf55f733",
+            "name": "vec3",
+            "type_name": "nos.fb.vec3",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": 149.749268, "y": 109.801041, "z": 34.700001 },
+            "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+            "meta_data_map": [
+              { "key": "Category", "value": "" }
+            ],
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "2bdd9fba-9dc0-4546-8d93-2a06a3197f12" }
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "0a67a3b7-16a5-440d-8087-22e7084fa332",
+              "name": "Make",
+              "class_name": "nos.reflect.MakeDynamic",
+              "pins": [
+                {
+                  "id": "27404a3a-242b-4995-a709-3ceb77a11123",
+                  "name": "Output",
+                  "type_name": "nos.fb.Transform",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "position": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "d40c34b8-5b26-4dac-a2be-14d99001903e",
+                  "name": "position",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "8264443d-7ad0-4e0a-836c-3cc148f4a9c4",
+                  "name": "rotation",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "a0fea256-4fcb-4ad6-bc18-704c9b09bedb",
+                  "name": "scale",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.0, "y": 1.0, "z": 1.0 },
+                  "def": { "x": 1.0, "y": 1.0, "z": 1.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 690.0, "y": 179.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "template_parameters": [
+                { "name": "Type", "type_name": "string", "value": "nos.fb.Transform" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "5a988ef5-f76a-43da-8b60-f52763b368e5",
+              "name": "vec3 to vec3d",
+              "class_name": "cast.vec3-vec3d",
+              "pins": [
+                {
+                  "id": "e95f57d3-6432-4857-8c28-a925cc40196a",
+                  "name": "vec3",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 149.749268, "y": 109.801041, "z": 34.700001 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "38e10517-b655-4593-a215-fdf3fb03241c",
+                  "name": "vec3d",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 536.0, "y": 192.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "38dbe610-8d80-4f5f-b004-fd35cd32fe79",
+              "name": "ToTransformMatrix",
+              "class_name": "nos.math.ToTransformMatrix",
+              "pins": [
+                {
+                  "id": "5181ddfa-cf70-47ac-9da7-775a2de1f673",
+                  "name": "Transform",
+                  "type_name": "nos.fb.Transform",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "position": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "e29825fe-df25-475b-b077-a6bb74fe7fdc",
+                  "name": "Matrix",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 915.0, "y": 178.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 1, "minor": 9, "patch": 3 }
+            },
+            {
+              "id": "fd110008-1a8e-4038-95f1-269062c8dd73",
+              "name": "Matrix",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "f2e94929-6e10-4bb4-a104-516a70e56eb6",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "6f2ec7d3-a17b-4f85-9b20-f2f1a23b2195",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "referred_by": [
+                    "3397e8ac-f446-47c4-8061-45c1d11b14f6"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 1123.0, "y": 189.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "43ff33ff-2d69-497f-a711-f99cf809d1d6",
+              "name": "vec3",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "b9b59ffe-3561-4f8e-9c92-a32e82d4b3e8",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 149.749268, "y": 109.801041, "z": 34.700001 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "2bdd9fba-9dc0-4546-8d93-2a06a3197f12",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 149.749268, "y": 109.801041, "z": 34.700001 },
+                  "referred_by": [
+                    "0e3b701c-f197-428c-8043-7af3bf55f733"
+                  ],
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 422.0, "y": 192.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "connections": [
+            { "from": "27404a3a-242b-4995-a709-3ceb77a11123", "to": "5181ddfa-cf70-47ac-9da7-775a2de1f673", "id": "38cedba4-0e79-4a3d-ac0c-06588ba6738c" },
+            { "from": "38e10517-b655-4593-a215-fdf3fb03241c", "to": "d40c34b8-5b26-4dac-a2be-14d99001903e", "id": "64ad328e-c57a-4086-951e-731d62f945b7" },
+            { "from": "e29825fe-df25-475b-b077-a6bb74fe7fdc", "to": "f2e94929-6e10-4bb4-a104-516a70e56eb6", "id": "139ba791-11c4-4ea7-a9ee-766867a36e92" },
+            { "from": "b9b59ffe-3561-4f8e-9c92-a32e82d4b3e8", "to": "e95f57d3-6432-4857-8c28-a925cc40196a", "id": "6cd3d7a7-4f16-4322-8de1-5c698abebb41" }
+          ] },
+        "function_category": "Default Node",
+        "display_name": "Translation Matrix",
+        "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosGraphics/Nodes/WorldToScreen.nosnode
+++ b/Plugins/nosGraphics/Nodes/WorldToScreen.nosnode
@@ -1,0 +1,1737 @@
+{ "nodes": [
+    {
+      "class_name": "nos.graphics.WorldToScreen",
+			"menu_info": {
+				"category": "Graphics|Math",
+				"display_name": "World To Screen"
+			},
+      "node": {
+        "id": "880c0e9b-b621-424d-b313-3a91fbc6b7ea",
+        "name": "World2Screen",
+        "class_name": "nos.graphics.WorldToScreen",
+        "pins": [
+          {
+            "id": "92fe05c5-2678-4515-bfb6-4563c6c16c46",
+            "name": "Output",
+            "type_name": "nos.fb.vec2",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_ONLY",
+            "visualizer": {
+            },
+            "data": { "x": 0.342611, "y": 0.542192 },
+            "def": { "x": 0.0, "y": 0.0 },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "a9f7baf7-8682-40a1-b65f-52062516ec87" },
+            "connection_conditions": "!array"
+          },
+          {
+            "id": "5fcbdb2f-e94d-49d8-ad96-fbca98e2ec35",
+            "name": "vec3",
+            "type_name": "nos.fb.vec3",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+            "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "c1619122-3292-4930-b6a1-37fa14aa606e" }
+          },
+          {
+            "id": "51ff0f6f-bda7-4e27-8294-c6ad50d68179",
+            "name": "View",
+            "type_name": "nos.fb.mat4",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "7d2aaca0-a582-4cdb-8463-e38cc5cc28c8" }
+          },
+          {
+            "id": "181fae32-762b-48fa-a143-527b3d5e4b20",
+            "name": "B",
+            "type_name": "nos.fb.mat4",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "ddac1b1a-f4b7-483e-af76-63fe9e45aa91" }
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "48d80981-48a8-47ed-9316-057faf484d9d",
+              "name": "Output",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "b912c178-ed1b-44fd-bd5c-e8baef11bdb6",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "a9f7baf7-8682-40a1-b65f-52062516ec87",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.342611, "y": 0.542192 },
+                  "referred_by": [
+                    "92fe05c5-2678-4515-bfb6-4563c6c16c46"
+                  ],
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                }
+              ],
+              "pos": { "x": 987.0, "y": -35.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "UV",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "c048f182-7bbf-47d7-9869-b836d69df98b",
+              "name": "MakeTranslationMatrix",
+              "class_name": "nos.graphics.TranslationMatrix",
+              "pins": [
+                {
+                  "id": "955037f2-3f9b-43e6-9ad8-753ee412f9fb",
+                  "name": "Matrix",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "f7a8e8c9-d130-4acf-a5a8-6c8ddacc6304" }
+                },
+                {
+                  "id": "a99114cc-de4b-45e4-b326-10d3a41beef7",
+                  "name": "vec3",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "a724ed3f-7848-4f1c-a032-d15382106640" }
+                }
+              ],
+              "pos": { "x": 589.0, "y": -98.0 },
+              "contents_type": "Graph",
+              "contents": { "nodes": [
+                  {
+                    "id": "9d9a2ff4-4955-43f2-923d-3481a5e4ed97",
+                    "name": "Make",
+                    "class_name": "nos.reflect.MakeDynamic",
+                    "pins": [
+                      {
+                        "id": "64c46c13-90f6-4998-9207-ae9094271e80",
+                        "name": "Output",
+                        "type_name": "nos.fb.Transform",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "position": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                        "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "e1481265-b828-4c2b-ae17-1edabf7ee221",
+                        "name": "position",
+                        "type_name": "nos.fb.vec3d",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "741e98f4-514a-441b-afa1-7f8f1be8f1d3",
+                        "name": "rotation",
+                        "type_name": "nos.fb.vec3d",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "db7ae136-f65a-430c-ba1d-f9dd9b583083",
+                        "name": "scale",
+                        "type_name": "nos.fb.vec3d",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 1.0, "y": 1.0, "z": 1.0 },
+                        "def": { "x": 1.0, "y": 1.0, "z": 1.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 690.0, "y": 179.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "template_parameters": [
+                      { "name": "Type", "type_name": "string", "value": "nos.fb.Transform" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "96c3c4b5-cf9d-4765-9d05-d2172a963238",
+                    "name": "vec3 to vec3d",
+                    "class_name": "cast.vec3-vec3d",
+                    "pins": [
+                      {
+                        "id": "36d3c472-0944-4deb-b4c6-98780a4196e6",
+                        "name": "vec3",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 149.749268, "y": 109.801041, "z": 34.700001 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "67b59235-d234-4cc8-9385-cdf80169f733",
+                        "name": "vec3d",
+                        "type_name": "nos.fb.vec3d",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 536.0, "y": 192.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "d5954ff3-c696-4522-a90d-9e6ff1d6cdc5",
+                    "name": "ToTransformMatrix",
+                    "class_name": "nos.math.ToTransformMatrix",
+                    "pins": [
+                      {
+                        "id": "83b61954-c1fb-4252-9bec-2dd337cacf30",
+                        "name": "Transform",
+                        "type_name": "nos.fb.Transform",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "position": { "x": 149.749267578125, "y": 109.801040649414, "z": 34.700000762939 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                        "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "d18fc437-40a4-479b-9400-8b95bd0da2f6",
+                        "name": "Matrix",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 915.0, "y": 178.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+                  },
+                  {
+                    "id": "33dfa800-dbbb-4c27-8011-929ad205296d",
+                    "name": "Matrix",
+                    "class_name": "nos.internal.GraphOutput",
+                    "pins": [
+                      {
+                        "id": "c548d722-0da9-47cd-ae4e-927826552845",
+                        "name": "Input",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "f7a8e8c9-d130-4acf-a5a8-6c8ddacc6304",
+                        "name": "Output",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                        "referred_by": [
+                          "955037f2-3f9b-43e6-9ad8-753ee412f9fb"
+                        ],
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 1123.0, "y": 189.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "4dc01c91-879c-4f04-be04-9610a6d9d1ba",
+                    "name": "vec3",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "95240f8c-afe6-455a-8e70-8fe47c05bb64",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 149.749268, "y": 109.801041, "z": 34.700001 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "a724ed3f-7848-4f1c-a032-d15382106640",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "referred_by": [
+                          "a99114cc-de4b-45e4-b326-10d3a41beef7"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 422.0, "y": 192.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  }
+                ], "connections": [
+                  { "from": "67b59235-d234-4cc8-9385-cdf80169f733", "to": "e1481265-b828-4c2b-ae17-1edabf7ee221", "id": "a1040d50-4360-40b3-95aa-e6002c635542" },
+                  { "from": "d18fc437-40a4-479b-9400-8b95bd0da2f6", "to": "c548d722-0da9-47cd-ae4e-927826552845", "id": "eab6281a-bb22-4660-95e2-f158996f3980" },
+                  { "from": "64c46c13-90f6-4998-9207-ae9094271e80", "to": "83b61954-c1fb-4252-9bec-2dd337cacf30", "id": "1c25ae10-e8d0-4c77-8d49-f91ae6b7be1f" },
+                  { "from": "95240f8c-afe6-455a-8e70-8fe47c05bb64", "to": "36d3c472-0944-4deb-b4c6-98780a4196e6", "id": "49c1bb49-6fee-40fb-837c-6c993ba1b275" }
+                ] },
+              "function_category": "Default Node",
+              "display_name": "Translation Matrix",
+              "plugin_version": { "major": 0, "minor": 4, "patch": 0 }
+            },
+            {
+              "id": "65f230a0-e5b8-44e2-a9fb-ad3d9ecfe523",
+              "name": "Project",
+              "class_name": "nos.graphics.Project",
+              "pins": [
+                {
+                  "id": "7dc5a40b-c5c7-426e-9078-4b4e15d4c2b5",
+                  "name": "Model",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "15eef41c-a67f-485d-bba4-99c693e7af7c" },
+                  "display_name": "Model"
+                },
+                {
+                  "id": "ca64a3b6-7777-43be-bf93-68105000088b",
+                  "name": "View",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "8301ba2a-0bca-4b4e-8546-83e5ea890942" },
+                  "display_name": "View"
+                },
+                {
+                  "id": "44e99a35-5738-4014-8588-a4779db1f8e4",
+                  "name": "B",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "bb072eb5-db1e-4791-8f5d-bd16352bc5b5" }
+                },
+                {
+                  "id": "82ae6adf-69d1-4d16-b9e5-28c766f70dfa",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "35af97bb-7547-4355-b7e1-6a3f88f92c96" }
+                }
+              ],
+              "pos": { "x": 836.0, "y": -25.0 },
+              "contents_type": "Graph",
+              "contents": { "nodes": [
+                  {
+                    "id": "1286fdee-4807-440b-9b6d-f804f39ad0ce",
+                    "name": "Arithmetic (2)",
+                    "class_name": "nos.reflect.Arithmetic",
+                    "pins": [
+                      {
+                        "id": "1d2a6fa4-949a-41cb-a7ef-0b24758e1ad2",
+                        "name": "Output",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": 0.084384,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!resource"
+                      },
+                      {
+                        "id": "9b9c86ae-5e7c-4e73-9aa5-70573bad6b84",
+                        "name": "A",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 45.830833,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!resource"
+                      },
+                      {
+                        "id": "5b8df7c2-d70a-4e11-a01f-e5f646ea9fa4",
+                        "name": "B",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 543.124023,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!resource"
+                      }
+                    ],
+                    "pos": { "x": 1806.0, "y": 4.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Div",
+                    "template_parameters": [
+                      { "name": "Operator", "type_name": "nos.reflect.BinaryOperator", "value": "DIV" },
+                      { "name": "Type", "type_name": "string", "value": "float" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "ec31d437-206b-4e9a-a2fc-82fca7296297",
+                    "name": "Eval",
+                    "class_name": "nos.math.Eval",
+                    "pins": [
+                      {
+                        "id": "89346113-bbd3-48ae-97ed-e72700894e3b",
+                        "name": "Expression",
+                        "type_name": "string",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": "A * 0.5 + 0.5",
+                        "def": "",
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "f4d2df89-5f99-400e-b58c-0e3cfe77b3d1",
+                        "name": "Result",
+                        "type_name": "double",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": 0.342610880733,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "a9332c61-8377-4977-93e2-31b953ed00cc",
+                        "name": "Show_Expression",
+                        "type_name": "bool",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": true,
+                        "def": true,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "Show Expression In Node"
+                      },
+                      {
+                        "id": "4ed5b95a-da12-4a73-8afd-d6e149a75587",
+                        "name": "A",
+                        "type_name": "double",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -0.314778238535,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "f6251935-7db9-4113-bad6-7c57049e3969",
+                        "name": "B",
+                        "type_name": "double",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2569.0, "y": -140.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "status_messages": [
+                      { "text": "A * 0.5 + 0.5" }
+                    ],
+                    "description": "Evaluates a string expression",
+                    "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+                  },
+                  {
+                    "id": "17a799c7-c089-4022-bcca-d8441a9649ff",
+                    "name": "Break (1)",
+                    "class_name": "nos.reflect.Break",
+                    "pins": [
+                      {
+                        "id": "256344a4-0a60-4ba3-87f8-9860ee11e5c7",
+                        "name": "Input",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": -1.52512, "y": 0.034559, "z": -0.207524, "w": -0.207522 }, "y": { "x": -0.324149, "y": -0.162603, "z": 0.9764, "w": 0.976391 }, "z": { "x": 0.0, "y": -2.767091, "z": -0.059968, "w": -0.059968 }, "w": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "3b19dc7c-e272-4c35-ac47-6e46c6e9c617",
+                        "name": "x",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": -1.52512, "y": 0.034559, "z": -0.207524, "w": -0.207522 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "5cbfe724-4368-43ae-b8d4-cc6fa3e4bae1",
+                        "name": "y",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": -0.324149, "y": -0.162603, "z": 0.9764, "w": 0.976391 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "b2d4f3dd-fe00-4760-9882-b7334c117a33",
+                        "name": "z",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.0, "y": -2.767091, "z": -0.059968, "w": -0.059968 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "9d4c4703-bd36-450b-b77f-89afdfc5dd3b",
+                        "name": "w",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 1356.0, "y": -86.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "meta_data_map": [
+                      { "key": "PinVisibility", "value": "ShowAll" }
+                    ],
+                    "display_name": "Break nos.fb.mat4",
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "ac971b52-e648-4979-8a58-3062293da6b9",
+                    "name": "Eval (1)",
+                    "class_name": "nos.math.Eval",
+                    "pins": [
+                      {
+                        "id": "840a30a5-b054-4eee-b363-6a91dfd2624e",
+                        "name": "Expression",
+                        "type_name": "string",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": "A * 0.5 + 0.5",
+                        "def": "",
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "7001dddd-7fd4-48ea-a85e-ddd865ddf9fd",
+                        "name": "Result",
+                        "type_name": "double",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": 0.542191866785,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "18515343-4552-4e35-8c8c-842108af11c3",
+                        "name": "Show_Expression",
+                        "type_name": "bool",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": true,
+                        "def": true,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "Show Expression In Node"
+                      },
+                      {
+                        "id": "8a8faa36-5a04-48c6-ad07-ae90045f70f6",
+                        "name": "A",
+                        "type_name": "double",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.084383733571,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "10eb2647-63f5-4ec0-8fe6-3522984931c5",
+                        "name": "B",
+                        "type_name": "double",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2573.0, "y": -40.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "status_messages": [
+                      { "text": "A * 0.5 + 0.5" }
+                    ],
+                    "description": "Evaluates a string expression",
+                    "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+                  },
+                  {
+                    "id": "97a73ddd-8de2-4f4b-b156-34c15d5254af",
+                    "name": "double to float",
+                    "class_name": "cast.double-float",
+                    "pins": [
+                      {
+                        "id": "6c3e9336-6383-445a-995e-ddbc2076ce3b",
+                        "name": "double",
+                        "type_name": "double",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.342610880733,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "64af722c-8a50-4576-a22b-f0c4dcb3f94b",
+                        "name": "float",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": 0.342611,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2726.0, "y": -138.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "7ecf03d4-348e-4202-a62e-7d54def19af4",
+                    "name": "Transform (2)",
+                    "class_name": "nos.math.Transform",
+                    "pins": [
+                      {
+                        "id": "f27d3a71-243a-43bd-a07b-1f274c37eedf",
+                        "name": "A",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "Model"
+                      },
+                      {
+                        "id": "0d80aa6e-8727-43f7-931d-c5e8c54cef52",
+                        "name": "B",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": 59.655338, "y": -55.744328, "z": 469.072449, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "View"
+                      },
+                      {
+                        "id": "a6e8dd0f-4494-4c31-b12f-a461c0bff8b8",
+                        "name": "Result",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": -109.649261, "y": -16.533016, "z": 543.124023, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 880.0, "y": -97.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "ToView",
+                    "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+                  },
+                  {
+                    "id": "3ad349e8-88f2-4a7f-ad97-e57a6403b26d",
+                    "name": "Transform (1)",
+                    "class_name": "nos.math.Transform",
+                    "pins": [
+                      {
+                        "id": "7fb98ec2-e7fe-480f-aed2-d5b84031d2d3",
+                        "name": "A",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": -109.649261, "y": -16.533016, "z": 543.124023, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "MV"
+                      },
+                      {
+                        "id": "4c2995de-7ed0-41e9-9f63-423451836192",
+                        "name": "B",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "Proj"
+                      },
+                      {
+                        "id": "16f7ed1a-9f82-41b4-b1ad-2d6e4a3f0364",
+                        "name": "Result",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": -1.52512, "y": 0.034559, "z": -0.207524, "w": -0.207522 }, "y": { "x": -0.324149, "y": -0.162603, "z": 0.9764, "w": 0.976391 }, "z": { "x": 0.0, "y": -2.767091, "z": -0.059968, "w": -0.059968 }, "w": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 1116.0, "y": -52.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Projected",
+                    "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+                  },
+                  {
+                    "id": "b1ab4e28-545e-4ced-8226-c6a03ec606a4",
+                    "name": "Break (4)",
+                    "class_name": "nos.reflect.Break",
+                    "pins": [
+                      {
+                        "id": "2fef2c89-16f4-4192-a361-b6143e360ddc",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": -170.963623, "y": 45.830833, "z": 543.02948, "w": 543.124023 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "716758f8-de4f-461d-82c7-121ff53058f9",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -170.963623,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "98cf7c1f-abf2-45c5-9964-5284a312b3f4",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 45.830833,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "bbe52665-5ae3-4356-afc7-78106d9e9e88",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 543.02948,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "8e4630dc-ef3e-4989-a677-2637cf1b971a",
+                        "name": "w",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 543.124023,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 1580.0, "y": -52.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Break nos.fb.vec4",
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "9f570eae-80cd-409f-9b82-c010dfd54985",
+                    "name": "Model",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "5477478e-e6cf-46fc-b5a6-b5863d97d2fb",
+                        "name": "Output",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "Model"
+                      },
+                      {
+                        "id": "15eef41c-a67f-485d-bba4-99c693e7af7c",
+                        "name": "Input",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 1.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 1.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 }, "w": { "x": 149.749268, "y": 109.801041, "z": 34.700001, "w": 1.0 } },
+                        "referred_by": [
+                          "7dc5a40b-c5c7-426e-9078-4b4e15d4c2b5"
+                        ],
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "Model"
+                      }
+                    ],
+                    "pos": { "x": 680.0, "y": -52.866665 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "ddafdb11-07d4-446b-8e4e-f71ae29db534",
+                    "name": "float to double",
+                    "class_name": "cast.float-double",
+                    "pins": [
+                      {
+                        "id": "d53e8be4-ef7f-4867-86c7-b749c5996c25",
+                        "name": "float",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -0.314778,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "f125bc67-f1d8-484a-92bb-d3a408c22b99",
+                        "name": "double",
+                        "type_name": "double",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": -0.314778238535,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2414.0, "y": -109.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "754510b8-1d77-4c18-a3ba-7c9aac46f2c7",
+                    "name": "Break (5)",
+                    "class_name": "nos.reflect.Break",
+                    "pins": [
+                      {
+                        "id": "96971d30-eb63-44e8-acbb-b87f13cc4a3d",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec2",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": -0.314778, "y": 0.084384 },
+                        "def": { "x": 0.0, "y": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "061fea37-1876-4cb9-9913-e23788eb6f3b",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -0.314778,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "591cf57b-a28c-497d-b309-469e72d73b74",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.084384,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2216.0, "y": -84.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Break nos.fb.vec2",
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "c78afd9b-9ec0-477c-a317-fd93d39b1f14",
+                    "name": "Arithmetic (1)",
+                    "class_name": "nos.reflect.Arithmetic",
+                    "pins": [
+                      {
+                        "id": "40a74919-6c3a-42af-ae87-e0472a1c7604",
+                        "name": "Output",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": -0.314778,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!resource"
+                      },
+                      {
+                        "id": "77f63b94-74ed-4a0d-98d7-752bba9926c1",
+                        "name": "A",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -170.963623,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!resource"
+                      },
+                      {
+                        "id": "c58065db-6f44-4626-bd0f-3013328f737e",
+                        "name": "B",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 543.124023,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!resource"
+                      }
+                    ],
+                    "pos": { "x": 1804.0, "y": -97.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Div",
+                    "template_parameters": [
+                      { "name": "Operator", "type_name": "nos.reflect.BinaryOperator", "value": "DIV" },
+                      { "name": "Type", "type_name": "string", "value": "float" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "6bb541e9-86d2-4d9c-92cb-a9b6bbdd002d",
+                    "name": "double to float (1)",
+                    "class_name": "cast.double-float",
+                    "pins": [
+                      {
+                        "id": "554a988a-7571-49a0-94fc-3836b1045057",
+                        "name": "double",
+                        "type_name": "double",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.542191866785,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "acc861b7-3204-4acc-ba0f-41787e8ba54d",
+                        "name": "float",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": 0.542192,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2732.0, "y": -33.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "cfbfae51-ca2f-4484-9831-6b1ef2eec090",
+                    "name": "float to double (1)",
+                    "class_name": "cast.float-double",
+                    "pins": [
+                      {
+                        "id": "699e85d1-cc30-43cb-a54f-e5213223661e",
+                        "name": "float",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.084384,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "5afa8873-e8f2-4274-ba7b-b1e89246c413",
+                        "name": "double",
+                        "type_name": "double",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": 0.084383733571,
+                        "def": 0.0,
+                        "meta_data_map": [
+                          { "key": "Category", "value": "" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2416.0, "y": -55.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "89a51da7-5a09-4ac3-b10a-be0c47af4413",
+                    "name": "Make (4)",
+                    "class_name": "nos.reflect.MakeDynamic",
+                    "pins": [
+                      {
+                        "id": "be3f2a91-730f-4079-807e-aa1edcab22f9",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec2",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": -0.314778, "y": 0.084384 },
+                        "def": { "x": 0.0, "y": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "327987bb-b579-45cb-9951-766d6006fa16",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -0.314778,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "3cb7db24-773c-4bef-81d6-ad3601e35dce",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.084384,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 1976.0, "y": -84.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "template_parameters": [
+                      { "name": "Type", "type_name": "string", "value": "nos.fb.vec2" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "f148c74d-aa18-45ce-b21d-cc42cb2b5d48",
+                    "name": "Make (3)",
+                    "class_name": "nos.reflect.MakeDynamic",
+                    "pins": [
+                      {
+                        "id": "8a0a9877-b6d8-41fe-8325-a55f1f924d70",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec2",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.342611, "y": 0.542192 },
+                        "def": { "x": 0.0, "y": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "UV",
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "d3329016-43eb-477d-b4d9-f4ea3c596e08",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.342611,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "c81485ac-0d2d-417b-be9d-63b2f526acff",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.542192,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 2928.0, "y": -113.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "template_parameters": [
+                      { "name": "Type", "type_name": "string", "value": "nos.fb.vec2" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "56906a83-0883-4876-893f-b286497c86a8",
+                    "name": "View",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "8c8a6eac-d12e-4a92-bf12-5820bba33d6b",
+                        "name": "Output",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": -0.978151, "y": -0.012467, "z": -0.207522, "w": 0.0 }, "y": { "x": -0.207896, "y": 0.058658, "z": 0.976391, "w": 0.0 }, "z": { "x": 0.0, "y": 0.9982, "z": -0.059968, "w": 0.0 }, "w": { "x": 59.655338, "y": -55.744328, "z": 469.072449, "w": 1.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "View"
+                      },
+                      {
+                        "id": "8301ba2a-0bca-4b4e-8546-83e5ea890942",
+                        "name": "Input",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "referred_by": [
+                          "ca64a3b6-7777-43be-bf93-68105000088b"
+                        ],
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "display_name": "View"
+                      }
+                    ],
+                    "pos": { "x": 680.0, "y": 22.133335 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "fc18cae6-764b-4c93-8ac9-f4956e0a7598",
+                    "name": "B",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "85c1da37-12ae-4b7a-9208-daef527768dc",
+                        "name": "Output",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "bb072eb5-db1e-4791-8f5d-bd16352bc5b5",
+                        "name": "Input",
+                        "type_name": "nos.fb.mat4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "referred_by": [
+                          "44e99a35-5738-4014-8588-a4779db1f8e4"
+                        ],
+                        "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 664.0, "y": 87.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Projection",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "92bd896c-784e-4e14-b143-b5f8e02af666",
+                    "name": "Output",
+                    "class_name": "nos.internal.GraphOutput",
+                    "pins": [
+                      {
+                        "id": "14696077-ee97-4106-b71a-17e7d7a88ead",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec2",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.342611, "y": 0.542192 },
+                        "def": { "x": 0.0, "y": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "35af97bb-7547-4355-b7e1-6a3f88f92c96",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec2",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.0, "y": 0.0 },
+                        "referred_by": [
+                          "82ae6adf-69d1-4d16-b9e5-28c766f70dfa"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 3177.0, "y": -110.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "UV",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  }
+                ], "comments": [
+                  {
+                    "id": "0b89bbb1-0804-47d8-8208-906bdb79c52f",
+                    "name": "Comment",
+                    "hint": "Hint",
+                    "content": "Project local point to clip space",
+                    "pos": { "x": 1002.0, "y": -104.0 },
+                    "size": { "x": 419.0, "y": 180.0 },
+                    "bg_color": { "x": 0.342587, "y": 1.0, "z": 0.278761, "w": 0.3 }
+                  },
+                  {
+                    "id": "4d456ae8-a278-425c-bc60-64b5e675228d",
+                    "name": "Comment (2)",
+                    "hint": "Hint",
+                    "content": "Convert NDC to UV",
+                    "pos": { "x": 2567.0, "y": -125.0 },
+                    "size": { "x": 919.0, "y": 224.0 },
+                    "bg_color": { "x": 0.99115, "y": 0.39032, "z": 0.39032, "w": 0.3 }
+                  },
+                  {
+                    "id": "f2f7ceb8-a45f-4899-bcc1-2c8b7d036448",
+                    "name": "Comment (1)",
+                    "hint": "Hint",
+                    "content": "Perspective divide",
+                    "pos": { "x": 1660.0, "y": -76.0 },
+                    "size": { "x": 829.0, "y": 236.0 },
+                    "bg_color": { "x": 0.861938, "y": 0.889381, "z": 0.114124, "w": 0.3 }
+                  }
+                ], "connections": [
+                  { "from": "8e4630dc-ef3e-4989-a677-2637cf1b971a", "to": "5b8df7c2-d70a-4e11-a01f-e5f646ea9fa4", "id": "b4cb5aa9-4e1e-4a0d-ac49-4443f8eee9d5" },
+                  { "from": "f125bc67-f1d8-484a-92bb-d3a408c22b99", "to": "4ed5b95a-da12-4a73-8afd-d6e149a75587", "id": "601240ac-badb-4b25-9db2-1913f705437d" },
+                  { "from": "7001dddd-7fd4-48ea-a85e-ddd865ddf9fd", "to": "554a988a-7571-49a0-94fc-3836b1045057", "id": "b7c58684-70df-4f8b-adaa-ec4081b3ef9e" },
+                  { "from": "a6e8dd0f-4494-4c31-b12f-a461c0bff8b8", "to": "7fb98ec2-e7fe-480f-aed2-d5b84031d2d3", "id": "55ddf82a-b7d0-4da0-8a75-07efcfa7d31d" },
+                  { "from": "16f7ed1a-9f82-41b4-b1ad-2d6e4a3f0364", "to": "256344a4-0a60-4ba3-87f8-9860ee11e5c7", "id": "542c5f4d-68dc-409c-8bca-4e71b13f1fe1" },
+                  { "from": "f4d2df89-5f99-400e-b58c-0e3cfe77b3d1", "to": "6c3e9336-6383-445a-995e-ddbc2076ce3b", "id": "5ad4a583-4944-4803-9d46-cab557677dbc" },
+                  { "from": "061fea37-1876-4cb9-9913-e23788eb6f3b", "to": "d53e8be4-ef7f-4867-86c7-b749c5996c25", "id": "e5daea82-21a6-4055-a42a-368a1cad6bea" },
+                  { "from": "716758f8-de4f-461d-82c7-121ff53058f9", "to": "77f63b94-74ed-4a0d-98d7-752bba9926c1", "id": "569c6aaa-2955-4907-b51a-b95f813803a8" },
+                  { "from": "64af722c-8a50-4576-a22b-f0c4dcb3f94b", "to": "d3329016-43eb-477d-b4d9-f4ea3c596e08", "id": "75589a6f-d48d-4576-8bcd-a9f35f61e375" },
+                  { "from": "98cf7c1f-abf2-45c5-9964-5284a312b3f4", "to": "9b9c86ae-5e7c-4e73-9aa5-70573bad6b84", "id": "15c12f84-acab-483c-985e-87f1d29ab4f6" },
+                  { "from": "9d4c4703-bd36-450b-b77f-89afdfc5dd3b", "to": "2fef2c89-16f4-4192-a361-b6143e360ddc", "id": "1edc438a-5ea5-4853-bdbd-a52775caa78d" },
+                  { "from": "5afa8873-e8f2-4274-ba7b-b1e89246c413", "to": "8a8faa36-5a04-48c6-ad07-ae90045f70f6", "id": "f2111787-255c-4a19-bf08-138631e68e86" },
+                  { "from": "8e4630dc-ef3e-4989-a677-2637cf1b971a", "to": "c58065db-6f44-4626-bd0f-3013328f737e", "id": "94a510d1-0b1b-43eb-8b49-2bd94dff2e7c" },
+                  { "from": "591cf57b-a28c-497d-b309-469e72d73b74", "to": "699e85d1-cc30-43cb-a54f-e5213223661e", "id": "5559894f-d8ef-4b6f-88ed-9557507bd0ad" },
+                  { "from": "1d2a6fa4-949a-41cb-a7ef-0b24758e1ad2", "to": "3cb7db24-773c-4bef-81d6-ad3601e35dce", "id": "cb5307d4-7138-4706-b740-908ab6e4f327" },
+                  { "from": "be3f2a91-730f-4079-807e-aa1edcab22f9", "to": "96971d30-eb63-44e8-acbb-b87f13cc4a3d", "id": "5e5df58a-7eb4-478f-9d98-39fe86005809" },
+                  { "from": "40a74919-6c3a-42af-ae87-e0472a1c7604", "to": "327987bb-b579-45cb-9951-766d6006fa16", "id": "b5456b27-f927-4f6e-a56f-8512f822cc73" },
+                  { "from": "acc861b7-3204-4acc-ba0f-41787e8ba54d", "to": "c81485ac-0d2d-417b-be9d-63b2f526acff", "id": "3230862d-754b-43fa-ae5c-e6496341b5ba" },
+                  { "from": "5477478e-e6cf-46fc-b5a6-b5863d97d2fb", "to": "f27d3a71-243a-43bd-a07b-1f274c37eedf", "id": "0b003d08-959a-4dc8-bcb7-6a4ebc1325af" },
+                  { "from": "8c8a6eac-d12e-4a92-bf12-5820bba33d6b", "to": "0d80aa6e-8727-43f7-931d-c5e8c54cef52", "id": "755fd7bc-ea7b-4675-9f6a-92686db31809" },
+                  { "from": "85c1da37-12ae-4b7a-9208-daef527768dc", "to": "4c2995de-7ed0-41e9-9f63-423451836192", "id": "b8110b52-e7a3-481e-b765-5a0a28c3ed33" },
+                  { "from": "8a0a9877-b6d8-41fe-8325-a55f1f924d70", "to": "14696077-ee97-4106-b71a-17e7d7a88ead", "id": "4329746c-5a64-4899-83b3-752b7f7e9375" }
+                ] },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 4, "patch": 0 }
+            },
+            {
+              "id": "805a0190-d517-4db0-b059-526c545dbe3f",
+              "name": "vec3",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "6ef06a48-8a74-43fe-b5f1-517b579ebbc6",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "c1619122-3292-4930-b6a1-37fa14aa606e",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "referred_by": [
+                    "5fcbdb2f-e94d-49d8-ad96-fbca98e2ec35"
+                  ],
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 351.0, "y": -86.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "WorldPosition",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "dd2848b7-3401-4ed2-ae47-c9d6c57a9f91",
+              "name": "B",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "30d4c60d-b1d6-407c-900d-5670881f53f9",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ddac1b1a-f4b7-483e-af76-63fe9e45aa91",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "referred_by": [
+                    "181fae32-762b-48fa-a143-527b3d5e4b20"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 364.0, "y": 34.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Projection",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "5f4974ef-1c8d-4740-a017-cd6fbe31b263",
+              "name": "View",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "c427f615-3d8f-4fb5-9598-466546f3f7d8",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "7d2aaca0-a582-4cdb-8463-e38cc5cc28c8",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "referred_by": [
+                    "51ff0f6f-bda7-4e27-8294-c6ad50d68179"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 381.0, "y": -23.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "connections": [
+            { "from": "955037f2-3f9b-43e6-9ad8-753ee412f9fb", "to": "7dc5a40b-c5c7-426e-9078-4b4e15d4c2b5", "id": "a512c2ea-a629-468e-af15-e57b3b6ea8ce" },
+            { "from": "82ae6adf-69d1-4d16-b9e5-28c766f70dfa", "to": "b912c178-ed1b-44fd-bd5c-e8baef11bdb6", "id": "c9346c39-c2b2-4007-a6f3-836089858da9" },
+            { "from": "6ef06a48-8a74-43fe-b5f1-517b579ebbc6", "to": "a99114cc-de4b-45e4-b326-10d3a41beef7", "id": "f9c9618a-6085-43b2-957d-1260ede44e3d" },
+            { "from": "c427f615-3d8f-4fb5-9598-466546f3f7d8", "to": "ca64a3b6-7777-43be-bf93-68105000088b", "id": "15ead84a-9e6b-4d49-ac84-2ff411824e2c" },
+            { "from": "30d4c60d-b1d6-407c-900d-5670881f53f9", "to": "44e99a35-5738-4014-8588-a4779db1f8e4", "id": "eea1cbd7-57e9-40f3-a651-2acbe245afb9" }
+          ] },
+        "function_category": "Default Node",
+        "display_name": "World To Screen",
+        "plugin_version": { "major": 0, "minor": 4, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosGraphics/Shaders/BillboardMask.frag
+++ b/Plugins/nosGraphics/Shaders/BillboardMask.frag
@@ -1,0 +1,9 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(location = 0) out vec4 rt;
+
+void main()
+{   
+    rt = vec4(1.0);
+}

--- a/Plugins/nosGraphics/Shaders/BillboardMask.vert
+++ b/Plugins/nosGraphics/Shaders/BillboardMask.vert
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout (binding = 0, std430) uniform UBO 
+{
+    mat4 MVP;
+} ubo;
+
+const vec2 pos[6] =
+    vec2[6](
+        vec2(+0.5, +1.0),
+        vec2(-0.5, +1.0),
+        vec2(+0.5, 0.0),
+        vec2(+0.5, 0.0),
+        vec2(-0.5, +1.0),
+        vec2(-0.5, 0.0));
+
+void main() 
+{
+    vec4 vertPos = vec4(pos[gl_VertexIndex].x, 0.0, pos[gl_VertexIndex].y, 1.0);
+    vec4 clipPos = ubo.MVP * vertPos;
+    gl_Position = clipPos;
+}

--- a/Plugins/nosGraphics/Shaders/NormalizedDepthToDepthBuffer.frag
+++ b/Plugins/nosGraphics/Shaders/NormalizedDepthToDepthBuffer.frag
@@ -1,0 +1,46 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(binding = 0) uniform sampler2D Input;
+layout (binding = 1, std430) uniform UBO 
+{
+    float Scale;
+    float ClipNear;
+    float ClipFar;
+} ubo;
+
+
+layout(location = 0) out float FragColor;
+layout(location = 0) in vec2 uv;
+
+float NormalizedDepthToDepthBufValue(
+    float normalizedDepth,
+    float scale,
+    vec2 uv,
+    float zNear,
+    float zFar)
+{
+    float zView = normalizedDepth * scale;
+
+    float depth =
+        zFar / (zFar - zNear) -
+        (zFar * zNear) / ((zFar - zNear) * zView);
+
+    return clamp(depth, 0.0, 1.0);
+}
+
+void main()
+{
+    float normalizedDepth = texture(Input, uv).r;
+    float finDepth = NormalizedDepthToDepthBufValue(
+        normalizedDepth,
+        ubo.Scale,
+        uv,
+        ubo.ClipNear,
+        ubo.ClipFar);
+
+    gl_FragDepth = finDepth;
+    FragColor = finDepth;
+}

--- a/Plugins/nosGraphics/Shaders/ShadowMask.frag
+++ b/Plugins/nosGraphics/Shaders/ShadowMask.frag
@@ -1,0 +1,31 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(binding = 1) uniform sampler2D DepthTexture;
+
+layout (binding = 0, std430) uniform UBO 
+{
+    mat4 MVP;
+    mat4 InvViewProj;
+    float GroundLevel;
+} ubo;
+
+layout(location = 0) out vec4 rt;
+layout(location = 0) in vec2 uv;
+
+void main()
+{   
+    ivec2 depthTextureSize = textureSize(DepthTexture, 0);
+    vec2 screenUv = gl_FragCoord.xy / vec2(depthTextureSize);
+    float sceneDepth = texture(DepthTexture, screenUv).r;
+    if (sceneDepth >= 1.0)
+        discard;
+
+    vec2 ndc = vec2(screenUv.x * 2.0 - 1.0, screenUv.y * 2.0 - 1.0);
+    vec4 worldPos = ubo.InvViewProj * vec4(ndc, sceneDepth, 1.0);
+    worldPos /= worldPos.w;
+    if (worldPos.z >= ubo.GroundLevel)
+        discard;
+
+    rt = vec4(uv.yyy, 1.0);
+}

--- a/Plugins/nosGraphics/Shaders/ShadowMask.vert
+++ b/Plugins/nosGraphics/Shaders/ShadowMask.vert
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout (binding = 0, std430) uniform UBO 
+{
+    mat4 MVP;
+    mat4 InvViewProj;
+    float GroundLevel;
+} ubo;
+
+layout(location = 0) out vec2 uv;
+
+const vec2 pos[6] =
+    vec2[6](
+        vec2(+0.5, 0.0),
+        vec2(-0.5, 0.0),
+        vec2(+0.5, -1.0),
+        vec2(+0.5, -1.0),
+        vec2(-0.5, 0.0),
+        vec2(-0.5, -1.0));
+
+void main() 
+{
+    uv = vec2(pos[gl_VertexIndex].x + 0.5, pos[gl_VertexIndex].y + 1.0);
+    vec4 vertPos = vec4(pos[gl_VertexIndex].x, 0.0, pos[gl_VertexIndex].y, 1.0);
+    vec4 clipPos = ubo.MVP * vertPos;
+    gl_Position = clipPos;
+}

--- a/Plugins/nosGraphics/Source/BillboardMask.cpp
+++ b/Plugins/nosGraphics/Source/BillboardMask.cpp
@@ -1,0 +1,314 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosGraphics/Graphics_generated.h>
+#include <nosSysVulkan/Helpers.hpp>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+namespace nos::graphics
+{
+NOS_REGISTER_NAME(BillboardMask)
+
+NOS_REGISTER_NAME(Position)
+NOS_REGISTER_NAME(Size)
+NOS_REGISTER_NAME(RenderView)
+NOS_REGISTER_NAME(Resolution)
+NOS_REGISTER_NAME(OutRenderTarget)
+NOS_REGISTER_NAME(OutDepth)
+NOS_REGISTER_NAME(InDepth)
+NOS_REGISTER_NAME(ReadInDepth)
+NOS_REGISTER_NAME(ShadowDepth)
+NOS_REGISTER_NAME(GroundLevel)
+
+NOS_REGISTER_NAME(BillboardMask_Pass)
+NOS_REGISTER_NAME(ShadowMask_Pass)
+
+struct BillboardMask : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	enum class StatusMessageType
+	{
+		FailedToCreateRenderTarget = 1,
+		FailedToCreateDepthBuffer = 2,
+		InvalidInputDepth = 3,
+	};
+
+	void OnPinValueChanged(nos::Name pinName, uuid const& pinId, nosBuffer value) override
+	{
+		if (pinName == NSN_ReadInDepth)
+		{
+			bool readInDepth = value.Data ? *static_cast<const bool*>(value.Data) : false;
+			if (readInDepth)
+			{
+				SetPinOrphanState(NSN_InDepth, nos::fb::PinOrphanStateType::ACTIVE);
+			}
+			else
+			{
+				SetPinOrphanState(NSN_InDepth, nos::fb::PinOrphanStateType::ORPHAN, "Read In Depth is disabled");
+			}
+		}
+	}
+
+	std::unordered_map<StatusMessageType, nos::fb::TNodeStatusMessage> ActiveStatusMessages;
+
+	void SerializeAndSendStatusMessages()
+	{
+		if (ActiveStatusMessages.size() == 0)
+		{
+			ClearNodeStatusMessages();
+			return;
+		}
+		std::vector<nos::fb::TNodeStatusMessage> messages;
+		messages.reserve(ActiveStatusMessages.size());
+		for (const auto& [type, statusMessage] : ActiveStatusMessages)
+		{
+			messages.push_back(statusMessage);
+		}
+		SetNodeStatusMessages(messages);
+	}
+
+	void SetOrAddStatusMessage(StatusMessageType msgType, nos::fb::TNodeStatusMessage message)
+	{
+		if (auto it = ActiveStatusMessages.find(msgType); it != ActiveStatusMessages.end())
+		{
+			if (it->second.text == message.text && it->second.type == message.type)
+				return;
+		}
+		ActiveStatusMessages[msgType] = std::move(message);
+		SerializeAndSendStatusMessages();
+	}
+
+	void RemoveStatusMessage(StatusMessageType msgType)
+	{
+		if (ActiveStatusMessages.erase(msgType) > 0)
+			SerializeAndSendStatusMessages();
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+		TRenderView view = pins.GetPinValue<TRenderView>(NSN_RenderView);
+		glm::vec2 size = *pins.GetPinValue<glm::vec2>(NSN_Size);
+		glm::vec3 position = *pins.GetPinValue<glm::vec3>(NSN_Position);
+
+		nosVec2u resolution = *pins.GetPinValue<nosVec2u>(NSN_Resolution);
+
+		// Output render target (engine-managed texture pin; recreate when size changes).
+		auto rt = pins.GetPinObject<nos::sys::vulkan::Texture>(NSN_OutRenderTarget);
+		{
+			auto rtInfo = nos::sys::vulkan::GetResourceInfo(rt);
+			if (!rtInfo || rtInfo->Width != resolution.x || rtInfo->Height != resolution.y)
+			{
+				nosTextureInfo ti{.Width = resolution.x,
+								  .Height = resolution.y,
+								  .Format = NOS_FORMAT_R8_UNORM,
+								  .Usage = nosImageUsage(NOS_IMAGE_USAGE_SAMPLED | NOS_IMAGE_USAGE_RENDER_TARGET)};
+				rt = nos::sys::vulkan::CreateTexture(ti, "Billboard Mask Output");
+				if (!rt)
+				{
+					SetOrAddStatusMessage(StatusMessageType::FailedToCreateRenderTarget,
+										  nos::fb::TNodeStatusMessage{
+											  .text = "Failed to create render target for Billboard Mask node.",
+											  .type = nos::fb::NodeStatusMessageType::FAILURE,
+										  });
+					return NOS_RESULT_FAILED;
+				}
+				SetPinObject(NSN_OutRenderTarget, rt);
+				RemoveStatusMessage(StatusMessageType::FailedToCreateRenderTarget);
+			}
+		}
+
+		auto depth = pins.GetPinObject<nos::sys::vulkan::Texture>(NSN_OutDepth);
+		bool readInDepth = *pins.GetPinValue<bool>(NSN_ReadInDepth);
+		if (readInDepth)
+		{
+			auto inDepth = pins.GetPinObject<nos::sys::vulkan::Texture>(NSN_InDepth);
+			auto inInfo = nos::sys::vulkan::GetResourceInfo(inDepth);
+			if (!inInfo || inInfo->Width != resolution.x || inInfo->Height != resolution.y ||
+				inInfo->Format != NOS_FORMAT_D32_SFLOAT)
+			{
+				SetOrAddStatusMessage(StatusMessageType::InvalidInputDepth,
+									  nos::fb::TNodeStatusMessage{
+										  .text = "Read In Depth is enabled, but InDepth is not a valid D32 depth texture matching Resolution.",
+										  .type = nos::fb::NodeStatusMessageType::FAILURE,
+									  });
+				nosEngine.LogW(
+					"Billboard Mask node is set to read input depth, but the provided texture is not a valid depth "
+					"texture. Please provide a valid depth texture.");
+				return NOS_RESULT_FAILED;
+			}
+			RemoveStatusMessage(StatusMessageType::InvalidInputDepth);
+			RemoveStatusMessage(StatusMessageType::FailedToCreateDepthBuffer);
+			SetPinObject(NSN_OutDepth, inDepth);
+			depth = inDepth;
+		}
+		else
+		{
+			RemoveStatusMessage(StatusMessageType::InvalidInputDepth);
+			auto depthInfo = nos::sys::vulkan::GetResourceInfo(depth);
+			if (!depthInfo || depthInfo->Width != resolution.x || depthInfo->Height != resolution.y ||
+				depthInfo->Format != NOS_FORMAT_D32_SFLOAT)
+			{
+				nosTextureInfo ti{.Width = resolution.x,
+								  .Height = resolution.y,
+								  .Format = NOS_FORMAT_D32_SFLOAT,
+								  .Usage = nosImageUsage(NOS_IMAGE_USAGE_SAMPLED | NOS_IMAGE_USAGE_DEPTH_STENCIL)};
+				depth = nos::sys::vulkan::CreateTexture(ti, "Billboard Mask Depth");
+				if (!depth)
+				{
+					SetOrAddStatusMessage(StatusMessageType::FailedToCreateDepthBuffer,
+										  nos::fb::TNodeStatusMessage{
+											  .text = "Failed to create depth buffer for Billboard Mask node.",
+											  .type = nos::fb::NodeStatusMessageType::FAILURE,
+										  });
+					return NOS_RESULT_FAILED;
+				}
+				SetPinObject(NSN_OutDepth, depth);
+				RemoveStatusMessage(StatusMessageType::FailedToCreateDepthBuffer);
+			}
+		}
+
+		if (!rt || !depth)
+		{
+			return NOS_RESULT_FAILED;
+		}
+
+		glm::mat4 viewMat = reinterpret_cast<glm::mat4&>(view.view);
+		glm::mat4 projMat = reinterpret_cast<glm::mat4&>(view.left_handed_projection_matrix);
+		glm::mat4 viewProjMat = projMat * viewMat;
+
+		glm::mat4 modelMat = glm::mat4(1.0f);
+		// Face the camera
+		glm::vec3 cameraPos = glm::vec3(glm::inverse(viewMat)[3]);
+		cameraPos.z = position.z;
+		glm::vec3 toCamera = glm::normalize(cameraPos - position);
+		glm::vec3 up = glm::vec3(0.0f, 0.0f, 1.0f);
+		glm::vec3 right = glm::normalize(glm::cross(toCamera, up));
+		modelMat = glm::translate(modelMat, position);
+		modelMat[0] = glm::vec4(right, 0.0f);
+		modelMat[1] = glm::vec4(toCamera, 0.0f);
+		modelMat[2] = glm::vec4(up, 0.0f);
+		// Translation writes to the 4th column, so no need to set it again
+		auto cmd = nos::sys::vulkan::BeginCmd(NOS_NAME("Billboard Mask"), NodeId);
+		{
+
+			glm::mat4 billboardMat = glm::scale(modelMat, glm::vec3(size.x, 1.0f, size.y));
+			glm::mat4 billboardMvp = viewProjMat * billboardMat;
+
+			auto bindings = std::array{nos::sys::vulkan::ShaderDataBinding(NOS_NAME("MVP"), billboardMvp)};
+
+			nosDrawCall drawCall{.Bindings = bindings.data(),
+								 .BindingCount = bindings.size(),
+								 .Vertices = nosVertexData{
+									 .IndexCount = 6,
+									 .DepthFunc = NOS_DEPTH_FUNCTION_LESS,
+									 .DepthWrite = true,
+									 .DepthTest = true,
+								 }};
+
+			nosRunPass2Params passParams{
+				.Key = NSN_BillboardMask_Pass,
+				.Output = rt,
+				.DrawCalls = &drawCall,
+				.DrawCallCount = 1,
+				.Wireframe = NOS_FALSE,
+				.Benchmark = 0,
+				.DoNotClear = false,
+				.ClearCol = {0.f, 0.f, 0.f, 0.f},
+				.DepthAttachment = nosDepthAttachment{.DepthBuffer = depth, .DoNotClear = readInDepth, .ClearValue = 1.0f}};
+			nosVulkan->RunPass2(cmd, &passParams);
+		}
+
+		float shadowDepth = *pins.GetPinValue<float>(NSN_ShadowDepth);
+		if (shadowDepth > 0.0f)
+		{
+			glm::mat4 invViewProjMat = glm::inverse(viewProjMat);
+			float groundLevel = *pins.GetPinValue<float>(NSN_GroundLevel);
+			auto shadowMat = glm::scale(modelMat, glm::vec3(size.x, 1.0f, shadowDepth));
+			glm::mat4 shadowMvp = viewProjMat * shadowMat;
+
+			auto bindings = std::array{nos::sys::vulkan::ShaderDataBinding(NOS_NAME("MVP"), shadowMvp),
+									   nos::sys::vulkan::ShaderDataBinding(NOS_NAME("InvViewProj"), invViewProjMat),
+									   nos::sys::vulkan::ShaderDataBinding(NOS_NAME("GroundLevel"), groundLevel),
+									   nos::sys::vulkan::ShaderTextureBinding(NOS_NAME("DepthTexture"), depth, NOS_TEXTURE_FILTER_LINEAR)};
+			nosDrawCall shadowDrawCall{.Bindings = bindings.data(),
+									 .BindingCount = bindings.size(),
+									 .Vertices = nosVertexData{
+										 .IndexCount = 6,
+										 .DepthFunc = NOS_DEPTH_FUNCTION_ALWAYS,
+										 .DepthWrite = false,
+										 .DepthTest = false,
+									 }};
+
+			nosRunPass2Params shadowPassParams{
+				.Key = NSN_ShadowMask_Pass,
+				.Output = rt,
+				.DrawCalls = &shadowDrawCall,
+				.DrawCallCount = 1,
+				.Wireframe = NOS_FALSE,
+				.Benchmark = 0,
+				.DoNotClear = true,
+				.ClearCol = {0.f, 0.f, 0.f, 0.f}};
+			nosVulkan->RunPass2(cmd, &shadowPassParams);
+		}
+
+		nosVulkan->End(cmd, nullptr);
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterBillboardMask(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NSN_BillboardMask, BillboardMask, fn);
+
+	fs::path root = nosEngine.Plugin->RootFolderPath;
+	auto billboardVertPath = (root / "Shaders" / "BillboardMask.vert").generic_string();
+	auto billboardFragPath = (root / "Shaders" / "BillboardMask.frag").generic_string();
+	auto shadowVertPath = (root / "Shaders" / "ShadowMask.vert").generic_string();
+	auto shadowFragPath = (root / "Shaders" / "ShadowMask.frag").generic_string();
+
+	// Register shaders
+	auto billboardMask_Frag = NOS_NAME("BillboardMask_Frag");
+	auto shadowMask_Frag = NOS_NAME("ShadowMask_Frag");
+	auto billboardMask_Vert = NOS_NAME("BillboardMask_Vert");
+	auto shadowMask_Vert = NOS_NAME("ShadowMask_Vert");
+	auto shaders =
+		std::array{nosShaderInfo{.ShaderName = billboardMask_Frag,
+								 .Source = {.Stage = NOS_SHADER_STAGE_FRAG, .GLSLPath = billboardFragPath.c_str()},
+								 .AssociatedNodeClassName = NSN_BillboardMask},
+				   nosShaderInfo{.ShaderName = shadowMask_Frag,
+								 .Source = {.Stage = NOS_SHADER_STAGE_FRAG, .GLSLPath = shadowFragPath.c_str()},
+								 .AssociatedNodeClassName = NSN_BillboardMask},
+				   nosShaderInfo{.ShaderName = billboardMask_Vert,
+								 .Source = {.Stage = NOS_SHADER_STAGE_VERT, .GLSLPath = billboardVertPath.c_str()},
+								 .AssociatedNodeClassName = NSN_BillboardMask},
+				   nosShaderInfo{.ShaderName = shadowMask_Vert,
+								 .Source = {.Stage = NOS_SHADER_STAGE_VERT, .GLSLPath = shadowVertPath.c_str()},
+								 .AssociatedNodeClassName = NSN_BillboardMask}};
+	auto ret = nosVulkan->RegisterShaders(shaders.size(), shaders.data());
+	if (NOS_RESULT_SUCCESS != ret)
+		return ret;
+
+	auto passes = std::array<nosPassInfo, 2>{nosPassInfo{
+												 .Key = NSN_BillboardMask_Pass,
+												 .Shader = billboardMask_Frag,
+												 .VertexShader = billboardMask_Vert,
+												 .MultiSample = 1,
+												 .Blend = NOS_BLEND_MODE_ALPHA_BLENDING,
+											 },
+											 nosPassInfo{
+												 .Key = NSN_ShadowMask_Pass,
+												 .Shader = shadowMask_Frag,
+												 .VertexShader = shadowMask_Vert,
+												 .MultiSample = 1,
+												 .Blend = NOS_BLEND_MODE_ALPHA_BLENDING,
+											 }};
+	ret = nosVulkan->RegisterPasses(passes.size(), passes.data());
+	if (NOS_RESULT_SUCCESS != ret)
+		return ret;
+
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/BillboardPositions.cpp
+++ b/Plugins/nosGraphics/Source/BillboardPositions.cpp
@@ -1,0 +1,66 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosGraphics/Graphics_generated.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+namespace nos::graphics
+{
+NOS_REGISTER_NAME(BillboardPositions)
+
+NOS_REGISTER_NAME(RenderView)
+NOS_REGISTER_NAME(Position)
+NOS_REGISTER_NAME(Width)
+NOS_REGISTER_NAME(Height)
+NOS_REGISTER_NAME(BottomLeft)
+NOS_REGISTER_NAME(BottomRight)
+NOS_REGISTER_NAME(TopLeft)
+NOS_REGISTER_NAME(TopRight)
+
+struct BillboardPositions : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+		TRenderView view = pins.GetPinValue<TRenderView>(NSN_RenderView);
+		float width = *pins.GetPinValue<float>(NSN_Width);
+		float height = *pins.GetPinValue<float>(NSN_Height);
+		glm::vec3 position = *pins.GetPinValue<glm::vec3>(NSN_Position);
+
+		glm::mat4 viewMat = reinterpret_cast<glm::mat4&>(view.view);
+
+		// Face the camera (billboard orientation)
+		glm::vec3 cameraPos = glm::vec3(glm::inverse(viewMat)[3]);
+		cameraPos.z = position.z;
+		glm::vec3 toCamera = glm::normalize(cameraPos - position);
+		glm::vec3 up = glm::vec3(0.0f, 0.0f, 1.0f);
+		glm::vec3 right = glm::normalize(glm::cross(toCamera, up));
+
+		// Calculate corner positions
+		// Height starts from the bottom (position is at the bottom center)
+		float halfWidth = width * 0.5f;
+
+		glm::vec3 bottomLeft = position - right * halfWidth;
+		glm::vec3 bottomRight = position + right * halfWidth;
+		glm::vec3 topLeft = position - right * halfWidth + up * height;
+		glm::vec3 topRight = position + right * halfWidth + up * height;
+
+		// Set output pins
+		SetPinValue(NSN_BottomLeft, nos::Buffer::From(bottomLeft));
+		SetPinValue(NSN_BottomRight, nos::Buffer::From(bottomRight));
+		SetPinValue(NSN_TopLeft, nos::Buffer::From(topLeft));
+		SetPinValue(NSN_TopRight, nos::Buffer::From(topRight));
+
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterBillboardPositions(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NSN_BillboardPositions, BillboardPositions, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/CameraGuide.cpp
+++ b/Plugins/nosGraphics/Source/CameraGuide.cpp
@@ -1,0 +1,223 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <Nodos/Plugin.hpp>
+
+#include <nosTrack/Track_generated.h>
+#include <Builtins_generated.h>
+#include <nosTrack/Coordinates_generated.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <string>
+
+// Shared CoordinateFrame basis matrices + Euler extraction.
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::graphics
+{
+// CoordinateFrame/Transform types + conversion helpers live in nos.track (shared,
+// to avoid a nos.graphics<->nos.track cycle).
+using namespace nos::track;
+
+NOS_REGISTER_NAME(Source)
+NOS_REGISTER_NAME(Target)
+NOS_REGISTER_NAME(Frame)
+NOS_REGISTER_NAME(PositionTolerance)
+NOS_REGISTER_NAME(AngleTolerance)
+NOS_REGISTER_NAME(Out)
+NOS_REGISTER_NAME(Guidance)
+NOS_REGISTER_NAME(GuidanceText)
+
+using GuideFrame = Frame;
+
+enum class GuideLevel : uint8_t
+{
+	Aligned,         // within tolerance -> INFO
+	NeedsCorrection, // a move/turn is required -> WARNING
+};
+
+// Snapshot of one evaluation. ExecuteNode is deterministic in its inputs, so two
+// equal snapshots produce an identical status message; comparing snapshots
+// (cheap value compare) lets us re-emit the status only when it actually changes
+// instead of every frame.
+struct GuideState
+{
+	GuideLevel Level = GuideLevel::Aligned;
+	double Fwd = 0.0, Right = 0.0, Up = 0.0;
+	double Pan = 0.0, Tilt = 0.0, Roll = 0.0;
+	double PosTol = 0.0, AngTol = 0.0;
+	bool operator==(GuideState const&) const = default;
+};
+
+// Describes the egocentric motion that turns Source into Target: translation
+// along Source's local axes (forward/right/up of the chosen frame) and rotation
+// about them (pan = yaw about up, tilt = pitch about right, roll about forward).
+// Source is passed straight through to Out (bypass).
+struct CameraGuideNode : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	// Last evaluated state; status is pushed only when this changes.
+	std::optional<GuideState> LastState;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+
+		nos::track::TTrack const& src = pins.GetPinValue<nos::track::TTrack>(NSN_Source);
+		nos::track::TTrack const& tgt = pins.GetPinValue<nos::track::TTrack>(NSN_Target);
+		auto frame = *pins.GetPinValue<GuideFrame>(NSN_Frame);
+		double posTol = *pins.GetPinValue<float>(NSN_PositionTolerance);
+		double angTol = *pins.GetPinValue<float>(NSN_AngleTolerance);
+
+		// Bypass: Source -> Out, unchanged.
+		SetPinValue(NSN_Out, nos::Buffer::From(src));
+
+		// Both Tracks carry Euler rotation in the same Frame, so they are decoded
+		// the same way -- no cross-frame mismatch is possible.
+		auto const& sr = src.rotation;
+		auto const& tr = tgt.rotation;
+		glm::dmat3 R_src = EulerToMat(frame.euler(), glm::dvec3(sr.x(), sr.y(), sr.z()));
+		glm::dmat3 R_tgt = EulerToMat(frame.euler(), glm::dvec3(tr.x(), tr.y(), tr.z()));
+
+		auto const& sp = src.location;
+		auto const& tp = tgt.location;
+		glm::dvec3 dWorld(tp.x() - sp.x(), tp.y() - sp.y(), tp.z() - sp.z());
+
+		// Express the positional delta in Source's local axes (egocentric).
+		glm::dvec3 dLocal = glm::transpose(R_src) * dWorld;
+
+		// Semantic axes (engine-space columns of S): 0 forward, 1 right, 2 up.
+		glm::dmat3 S = BasisMatrix(frame);
+		double fwd = glm::dot(dLocal, glm::dvec3(S[0]));
+		double right = glm::dot(dLocal, glm::dvec3(S[1]));
+		double up = glm::dot(dLocal, glm::dvec3(S[2]));
+
+		// Rotation guidance in camera-operator terms, taken against the frame's
+		// vertical (world up) rather than Source's local up. This is what keeps
+		// "looking around" honest: pan is a rotation about world up, tilt is the
+		// change in elevation, roll is the change in bank about forward. As long
+		// as both up-vectors stay vertical (no banking), roll comes out zero.
+		glm::dvec3 F0(S[0]); // forward axis
+		glm::dvec3 U0(S[2]); // up axis (vertical / pan axis)
+		glm::dvec3 fs = glm::normalize(R_src * F0);
+		glm::dvec3 ft = glm::normalize(R_tgt * F0);
+
+		auto elevation = [&](glm::dvec3 const& f) {
+			return std::asin(glm::clamp(glm::dot(f, U0), -1.0, 1.0));
+		};
+		// Bank: signed angle about forward between the actual up and the
+		// zero-roll up for that forward direction.
+		auto bank = [&](glm::dmat3 const& R) {
+			glm::dvec3 f = glm::normalize(R * F0);
+			glm::dvec3 r = glm::cross(f, U0);
+			double rl = glm::length(r);
+			if (rl < 1e-9) // looking straight up/down: bank is undefined
+				return 0.0;
+			r /= rl;
+			glm::dvec3 upRef = glm::cross(r, f); // zero-roll up for this forward
+			glm::dvec3 upR = R * U0;
+			return std::atan2(glm::dot(glm::cross(upRef, upR), f), glm::dot(upRef, upR));
+		};
+
+		// Pan: angle between the horizontal headings. The left/right side is
+		// decided by which side of Source's (horizontal) right axis the Target
+		// heading falls on -- a spatial test, so it stays correct in both left-
+		// and right-handed frames (a rotation-sign convention would not).
+		glm::dvec3 fsH = fs - glm::dot(fs, U0) * U0;
+		glm::dvec3 ftH = ft - glm::dot(ft, U0) * U0;
+		double pan = 0.0;
+		if (glm::length(fsH) > 1e-9 && glm::length(ftH) > 1e-9)
+		{
+			fsH = glm::normalize(fsH);
+			ftH = glm::normalize(ftH);
+			glm::dvec3 rs = R_src * glm::dvec3(S[1]); // Source right axis
+			rs = rs - glm::dot(rs, U0) * U0;          // horizontal component
+			double mag = std::acos(glm::clamp(glm::dot(fsH, ftH), -1.0, 1.0));
+			double side = glm::dot(ftH, rs); // > 0: Target heading is to the right
+			pan = side >= 0.0 ? mag : -mag;  // pan > 0 -> Pan right
+		}
+		double tilt = elevation(ft) - elevation(fs);
+		double roll = bank(R_tgt) - bank(R_src);
+		pan = glm::degrees(pan);
+		tilt = glm::degrees(tilt);
+		roll = glm::degrees(roll);
+
+		bool needsMove = std::abs(fwd) >= posTol || std::abs(right) >= posTol || std::abs(up) >= posTol;
+		bool needsTurn = std::abs(pan) >= angTol || std::abs(tilt) >= angTol || std::abs(roll) >= angTol;
+
+		GuideState state{
+			needsMove || needsTurn ? GuideLevel::NeedsCorrection : GuideLevel::Aligned,
+			fwd, right, up, pan, tilt, roll, posTol, angTol};
+
+		// Nothing changed since last frame -> don't re-emit the status.
+		if (LastState == state)
+			return NOS_RESULT_SUCCESS;
+		LastState = state;
+
+		std::string msg;
+		auto move = [&](double v, const char* pos, const char* neg) {
+			if (std::abs(v) < posTol)
+				return;
+			if (!msg.empty())
+				msg += ", ";
+			msg += std::format("{} {:.2f}", v >= 0 ? pos : neg, std::abs(v));
+		};
+		move(fwd, "Forward", "Back");
+		move(right, "Right", "Left");
+		move(up, "Up", "Down");
+
+		std::string rot;
+		auto turn = [&](double deg, const char* pos, const char* neg) {
+			if (std::abs(deg) < angTol)
+				return;
+			if (!rot.empty())
+				rot += ", ";
+			rot += std::format("{} {:.1f} deg", deg >= 0 ? pos : neg, std::abs(deg));
+		};
+		turn(pan, "Pan right", "Pan left");
+		turn(tilt, "Tilt up", "Tilt down");
+		// roll is a right-hand rotation about +forward; the operator looks along
+		// +forward, so positive reads as counter-clockwise.
+		turn(roll, "Roll CCW", "Roll CW");
+
+		std::string status;
+		if (state.Level == GuideLevel::Aligned)
+			status = "Aligned (within tolerance)";
+		else
+		{
+			if (!msg.empty())
+				status = "Move: " + msg;
+			if (!rot.empty())
+				status += (status.empty() ? "" : "\n") + std::string("Rotate: ") + rot;
+		}
+		SetNodeStatusMessage(status, state.Level == GuideLevel::Aligned
+										 ? fb::NodeStatusMessageType::INFO
+										 : fb::NodeStatusMessageType::WARNING);
+
+		// Structured guidance on an output pin; compose display text downstream.
+		TransformGuidance guidance(
+			state.Level == GuideLevel::Aligned ? AlignmentState::Aligned
+											   : AlignmentState::NeedsCorrection,
+			(float)fwd, (float)right, (float)up, (float)pan, (float)tilt, (float)roll);
+		SetPinValue(NSN_Guidance, nos::Buffer::From(guidance));
+
+		// Same text as the node status, for a downstream text renderer.
+		SetPinValue(NSN_GuidanceText, nos::Buffer(status.c_str(), status.size() + 1));
+
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterCameraGuide(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.graphics.CameraGuide"), CameraGuideNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+}  // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/ConvertCoordinateFrame.cpp
+++ b/Plugins/nosGraphics/Source/ConvertCoordinateFrame.cpp
@@ -1,0 +1,80 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <Nodos/Plugin.hpp>
+
+#include <Builtins_generated.h>
+#include <nosTrack/Coordinates_generated.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <cmath>
+
+// Shared CoordinateFrame basis matrices.
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::graphics
+{
+// CoordinateFrame/TransformQ types + conversion helpers live in nos.track (shared,
+// to avoid a nos.graphics<->nos.track cycle).
+using namespace nos::track;
+
+NOS_REGISTER_NAME(In)
+NOS_REGISTER_NAME(SourceFrame)
+NOS_REGISTER_NAME(TargetFrame)
+NOS_REGISTER_NAME(Out)
+
+// Converts a nos.graphics.TransformQ between coordinate frames. Mirrors
+// nos.track.ConvertTransform, but rotation is carried as a quaternion so no
+// Euler convention is involved: the quaternion is conjugated by the basis-change
+// matrix directly.
+struct ConvertCoordinateFrameNode : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+
+		auto* in = pins.GetPinValue<TransformQ>(NSN_In);
+		auto source = *pins.GetPinValue<Frame>(NSN_SourceFrame);
+		auto target = *pins.GetPinValue<Frame>(NSN_TargetFrame);
+
+		if (!CoordinateFrameValid(source) || !CoordinateFrameValid(target))
+		{
+			SetNodeStatusMessage("Source/Target frame is invalid: forward and up must be on different axes",
+								 fb::NodeStatusMessageType::FAILURE);
+			return NOS_RESULT_FAILED;
+		}
+
+		const FrameConvert conv = MakeFrameConvert(source, target);
+
+		const auto& p = in->position();
+		glm::dvec3 outPos = ConvertPosition(conv, glm::dvec3(p.x(), p.y(), p.z()));
+
+		// Rotation carried as a quaternion, so no Euler convention is involved: the
+		// quaternion is conjugated by the basis-change matrix directly.
+		const auto& r = in->rotation();
+		glm::dquat q = glm::normalize(glm::dquat(r.w(), r.x(), r.y(), r.z()));
+		glm::dquat outQ = ConvertRotation(conv, q);
+
+		const auto& s = in->scale();
+		glm::dvec3 outScale = ConvertScale(conv, glm::dvec3(s.x(), s.y(), s.z()));
+
+		TransformQ out(
+			fb::vec3d(outPos.x, outPos.y, outPos.z),
+			fb::vec4d(outQ.x, outQ.y, outQ.z, outQ.w),
+			fb::vec3d(outScale.x, outScale.y, outScale.z));
+
+		SetPinValue(NSN_Out, nos::Buffer::From(out));
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterConvertCoordinateFrame(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.graphics.ConvertCoordinateFrame"), ConvertCoordinateFrameNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+}  // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/GraphicsMain.cpp
+++ b/Plugins/nosGraphics/Source/GraphicsMain.cpp
@@ -1,0 +1,72 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+// Includes
+#include <Nodos/Plugin.hpp>
+#include <nosSysVulkan/nosVulkanSubsystem.h>
+
+NOS_INIT()
+NOS_VULKAN_INIT()
+
+NOS_BEGIN_IMPORT_DEPS()
+NOS_VULKAN_IMPORT()
+NOS_END_IMPORT_DEPS()
+
+namespace nos::graphics
+{
+enum Nodes : int
+{ // CPU nodes
+	TrackToView,
+	BillboardPositions,
+	HomographySolver,
+	ConvertCoordinateFrame,
+	CameraGuide,
+	TrackToTransformQ,
+	NormalizedDepthToDepthBuffer,
+	BillboardMask,
+	Count
+};
+
+nosResult RegisterTrackToView(nosNodeFunctions*);
+nosResult RegisterBillboardPositions(nosNodeFunctions*);
+nosResult RegisterHomographySolver(nosNodeFunctions*);
+nosResult RegisterConvertCoordinateFrame(nosNodeFunctions*);
+nosResult RegisterCameraGuide(nosNodeFunctions*);
+nosResult RegisterTrackToTransformQ(nosNodeFunctions*);
+nosResult RegisterNormalizedDepthToDepthBuffer(nosNodeFunctions*);
+nosResult RegisterBillboardMask(nosNodeFunctions*);
+
+struct PluginFunctions : nos::PluginFunctions
+{
+	nosResult NOSAPI_CALL ExportNodeFunctions(size_t& outSize, nosNodeFunctions** outFunctions)
+	{
+		outSize = Nodes::Count;
+		if (!outFunctions)
+			return NOS_RESULT_SUCCESS;
+#define GEN_CASE_NODE(name)                                                                                            \
+	case Nodes::name: {                                                                                                \
+		auto ret = Register##name(node);                                                                               \
+		if (NOS_RESULT_SUCCESS != ret)                                                                                 \
+			return ret;                                                                                                \
+		break;                                                                                                         \
+	}
+		for (int i = 0; i < Nodes::Count; ++i)
+		{
+			auto node = outFunctions[i];
+			switch ((Nodes)i)
+			{
+				GEN_CASE_NODE(TrackToView)
+				GEN_CASE_NODE(BillboardPositions)
+				GEN_CASE_NODE(HomographySolver)
+				GEN_CASE_NODE(ConvertCoordinateFrame)
+				GEN_CASE_NODE(CameraGuide)
+				GEN_CASE_NODE(TrackToTransformQ)
+				GEN_CASE_NODE(NormalizedDepthToDepthBuffer)
+				GEN_CASE_NODE(BillboardMask)
+			default: break;
+			}
+		}
+		return NOS_RESULT_SUCCESS;
+	}
+};
+NOS_EXPORT_PLUGIN_FUNCTIONS(PluginFunctions)
+} // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/HomographySolver.cpp
+++ b/Plugins/nosGraphics/Source/HomographySolver.cpp
@@ -1,0 +1,144 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <glm/glm.hpp>
+
+namespace nos::graphics
+{
+
+struct HomographySolverNodeContext : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	bool Failed = false;
+
+	// Solve 8x8 linear system Ax = b using Gaussian elimination with partial pivoting
+	static bool SolveLinearSystem(double A[8][8], double b[8], double x[8])
+	{
+		// Forward elimination with partial pivoting
+		for (int col = 0; col < 8; col++)
+		{
+			// Find pivot
+			int maxRow = col;
+			double maxVal = std::abs(A[col][col]);
+			for (int row = col + 1; row < 8; row++)
+			{
+				if (std::abs(A[row][col]) > maxVal)
+				{
+					maxVal = std::abs(A[row][col]);
+					maxRow = row;
+				}
+			}
+
+			if (maxVal < 1e-12)
+				return false; // Singular matrix
+
+			// Swap rows
+			if (maxRow != col)
+			{
+				std::swap(b[col], b[maxRow]);
+				for (int j = 0; j < 8; j++)
+					std::swap(A[col][j], A[maxRow][j]);
+			}
+
+			// Eliminate below
+			for (int row = col + 1; row < 8; row++)
+			{
+				double factor = A[row][col] / A[col][col];
+				b[row] -= factor * b[col];
+				for (int j = col; j < 8; j++)
+					A[row][j] -= factor * A[col][j];
+			}
+		}
+
+		// Back substitution
+		for (int row = 7; row >= 0; row--)
+		{
+			x[row] = b[row];
+			for (int j = row + 1; j < 8; j++)
+				x[row] -= A[row][j] * x[j];
+			x[row] /= A[row][row];
+		}
+
+		return true;
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+
+		glm::vec2 src[4], dst[4];
+		src[0] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Source 1")));
+		src[1] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Source 2")));
+		src[2] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Source 3")));
+		src[3] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Source 4")));
+		dst[0] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Target 1")));
+		dst[1] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Target 2")));
+		dst[2] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Target 3")));
+		dst[3] = *reinterpret_cast<const glm::vec2*>(params.GetPinValue<fb::vec2>(NOS_NAME("Target 4")));
+
+		// DLT: For each correspondence (x,y) -> (x',y') with h33 = 1:
+		//   h11*x + h12*y + h13 - h31*x*x' - h32*y*x' = x'
+		//   h21*x + h22*y + h23 - h31*x*y' - h32*y*y' = y'
+		// Unknowns: h11, h12, h13, h21, h22, h23, h31, h32
+
+		double A[8][8] = {};
+		double b[8] = {};
+
+		for (int i = 0; i < 4; i++)
+		{
+			double sx = src[i].x, sy = src[i].y;
+			double dx = dst[i].x, dy = dst[i].y;
+
+			int r0 = i * 2;
+			int r1 = i * 2 + 1;
+
+			// Row for x': h11*sx + h12*sy + h13 - h31*sx*dx - h32*sy*dx = dx
+			A[r0][0] = sx;  A[r0][1] = sy;  A[r0][2] = 1.0;
+			A[r0][3] = 0.0; A[r0][4] = 0.0; A[r0][5] = 0.0;
+			A[r0][6] = -sx * dx; A[r0][7] = -sy * dx;
+			b[r0] = dx;
+
+			// Row for y': h21*sx + h22*sy + h23 - h31*sx*dy - h32*sy*dy = dy
+			A[r1][0] = 0.0; A[r1][1] = 0.0; A[r1][2] = 0.0;
+			A[r1][3] = sx;  A[r1][4] = sy;  A[r1][5] = 1.0;
+			A[r1][6] = -sx * dy; A[r1][7] = -sy * dy;
+			b[r1] = dy;
+		}
+
+		double h[8] = {};
+		if (!SolveLinearSystem(A, b, h))
+		{
+			if (!Failed)
+			{
+				Failed = true;
+				SetNodeStatusMessage("Degenerate point configuration", fb::NodeStatusMessageType::FAILURE);
+			}
+			return NOS_RESULT_FAILED;
+		}
+
+		if (Failed)
+		{
+			Failed = false;
+			ClearNodeStatusMessages();
+		}
+
+		// Construct 3x3 homography matrix (column-major for GLM)
+		glm::mat3 H(
+			(float)h[0], (float)h[3], (float)h[6],  // column 0
+			(float)h[1], (float)h[4], (float)h[7],  // column 1
+			(float)h[2], (float)h[5], 1.0f           // column 2
+		);
+
+		SetPinValue(NOS_NAME("Homography"), reinterpret_cast<fb::mat3&>(H));
+
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterHomographySolver(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.graphics.HomographySolver"), HomographySolverNodeContext, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/NormalizedDepthToDepthBuffer.cpp
+++ b/Plugins/nosGraphics/Source/NormalizedDepthToDepthBuffer.cpp
@@ -1,0 +1,132 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosGraphics/Graphics_generated.h>
+#include <nosSysVulkan/Helpers.hpp>
+#include <glm/glm.hpp>
+
+namespace nos::graphics
+{
+NOS_REGISTER_NAME(NormalizedDepthToDepthBuffer)
+
+NOS_REGISTER_NAME(InDepth)
+NOS_REGISTER_NAME(RenderView)
+NOS_REGISTER_NAME(Scale)
+NOS_REGISTER_NAME(OutDepth)
+
+NOS_REGISTER_NAME(NormalizedDepthToDepthBuffer_Pass)
+NOS_REGISTER_NAME(NormalizedDepthToDepthBuffer_Frag)
+
+struct NormalizedDepthToDepthBuffer : NodeContext
+{
+	nos::ObjectRef TempColorOutput;
+	uint32_t TempW = 0, TempH = 0;
+
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+
+		TRenderView view = pins.GetPinValue<TRenderView>(NSN_RenderView);
+		if (!view.projection)
+		{
+			nosEngine.LogW("NormalizedDepthToDepthBuffer requires a valid RenderView projection.");
+			return NOS_RESULT_FAILED;
+		}
+
+		float scale = *pins.GetPinValue<float>(NSN_Scale);
+		glm::vec2 clipPlanes = reinterpret_cast<glm::vec2 const&>(view.projection->clip_planes);
+
+		// The output depth buffer is an engine-managed resource on the OutDepth pin.
+		auto outDepthInfo = nos::sys::vulkan::GetResourceInfo(pins.GetPinObject(NSN_OutDepth));
+		if (!outDepthInfo)
+		{
+			nosEngine.LogW("NormalizedDepthToDepthBuffer: OutDepth pin has no resource yet.");
+			return NOS_RESULT_FAILED;
+		}
+		uint32_t w = outDepthInfo->Texture.Width, h = outDepthInfo->Texture.Height;
+
+		// A render pass needs a color attachment; this throwaway target sized to the
+		// depth buffer satisfies that while the actual result is written to OutDepth.
+		if (!TempColorOutput || TempW != w || TempH != h)
+		{
+			nosResourceInfo info = {};
+			info.Type = NOS_RESOURCE_TYPE_TEXTURE;
+			info.Texture.Width = w;
+			info.Texture.Height = h;
+			info.Texture.Format = NOS_FORMAT_R8_UNORM;
+			info.Texture.Usage = nosImageUsage(NOS_IMAGE_USAGE_RENDER_TARGET | NOS_IMAGE_USAGE_SAMPLED);
+			TempColorOutput = {};
+			nosVulkan->CreateResource(&info, 0, "NormalizedDepthToDepthBuffer Temp Output", &TempColorOutput.GetStorage());
+			if (!TempColorOutput)
+			{
+				nosEngine.LogW("NormalizedDepthToDepthBuffer: failed to create temp color target.");
+				return NOS_RESULT_FAILED;   // leave TempW/TempH unchanged so creation retries next frame
+			}
+			TempW = w; TempH = h;
+		}
+
+		std::vector<nosShaderBinding> bindings = {
+			nos::sys::vulkan::ShaderTextureBinding(NOS_NAME("Input"), pins.GetPinObject(NSN_InDepth), NOS_TEXTURE_FILTER_LINEAR),
+			nos::sys::vulkan::ShaderDataBinding(NSN_Scale, scale),
+			nos::sys::vulkan::ShaderDataBinding(NOS_NAME("ClipNear"), clipPlanes.x),
+			nos::sys::vulkan::ShaderDataBinding(NOS_NAME("ClipFar"), clipPlanes.y),
+		};
+
+		nosCmd cmd = {};
+		nosCmdBeginParams beginParams{.Name = NOS_NAME("Normalized Depth To Depth Buffer"),
+									  .AssociatedNodeId = NodeId,
+									  .OutCmdHandle = &cmd};
+		nosVulkan->Begin(&beginParams);
+
+		nosRunPassParams pass = {};
+		pass.Key = NSN_NormalizedDepthToDepthBuffer_Pass;
+		pass.Bindings = bindings.data();
+		pass.BindingCount = bindings.size();
+		pass.Output = TempColorOutput;
+		pass.Benchmark = 0;
+		pass.DoNotClear = false;
+		pass.DepthAttachment = {
+			.DepthBuffer = pins.GetPinObject(NSN_OutDepth),
+			.DoNotClear = false,
+			.ClearValue = 1.0f,
+		};
+		pass.Vertices = {
+			.IndexCount = 6,
+			.DepthFunc = NOS_DEPTH_FUNCTION_ALWAYS,
+			.DepthWrite = true,
+			.DepthTest = true,
+		};
+
+		nosVulkan->RunPass(cmd, &pass);
+		nosVulkan->End(cmd, nullptr);
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterNormalizedDepthToDepthBuffer(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NSN_NormalizedDepthToDepthBuffer, NormalizedDepthToDepthBuffer, fn);
+
+	fs::path root = nosEngine.Plugin->RootFolderPath;
+	auto fragPath = (root / "Shaders" / "NormalizedDepthToDepthBuffer.frag").generic_string();
+
+	nosShaderInfo shader{
+		.ShaderName = NSN_NormalizedDepthToDepthBuffer_Frag,
+		.Source = {.Stage = NOS_SHADER_STAGE_FRAG, .GLSLPath = fragPath.c_str()},
+		.AssociatedNodeClassName = NSN_NormalizedDepthToDepthBuffer,
+	};
+
+	auto ret = nosVulkan->RegisterShaders(1, &shader);
+	if (ret != NOS_RESULT_SUCCESS)
+		return ret;
+
+	nosPassInfo pass = {
+		.Key = NSN_NormalizedDepthToDepthBuffer_Pass,
+		.Shader = NSN_NormalizedDepthToDepthBuffer_Frag,
+		.MultiSample = 1,
+	};
+
+	return nosVulkan->RegisterPasses(1, &pass);
+}
+} // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/TrackToTransformQ.cpp
+++ b/Plugins/nosGraphics/Source/TrackToTransformQ.cpp
@@ -1,0 +1,63 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <Nodos/Plugin.hpp>
+
+#include <nosTrack/Track_generated.h>
+#include <Builtins_generated.h>
+#include <nosTrack/Coordinates_generated.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+// Track.rotation is Euler degrees in a frame-specific convention; EulerToMat
+// turns it into a rotation matrix.
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::graphics
+{
+// CoordinateFrame/TransformQ types + EulerToMat() live in nos.track (shared, to
+// avoid a nos.graphics<->nos.track cycle).
+using namespace nos::track;
+
+NOS_REGISTER_NAME(Track)
+NOS_REGISTER_NAME(Frame)
+NOS_REGISTER_NAME(Out)
+
+// Converts a nos.sys.track.Track's location + Euler rotation into a
+// nos.graphics.TransformQ. The Euler angles are interpreted per Frame's euler
+// encoding and emitted as a quaternion; no frame conversion is performed, so the
+// output is expressed in Frame. Track carries no scale, so scale is identity.
+struct TrackToTransformQNode : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+
+		nos::track::TTrack const& track = pins.GetPinValue<nos::track::TTrack>(NSN_Track);
+		auto frame = *pins.GetPinValue<Frame>(NSN_Frame);
+
+		auto const& loc = track.location;
+		auto const& rot = track.rotation;
+
+		glm::dmat3 R = EulerToMat(frame.euler(), glm::dvec3(rot.x(), rot.y(), rot.z()));
+		glm::dquat q = glm::normalize(glm::quat_cast(R));
+
+		TransformQ out(
+			fb::vec3d(loc.x(), loc.y(), loc.z()),
+			fb::vec4d(q.x, q.y, q.z, q.w),
+			fb::vec3d(1.0, 1.0, 1.0));
+
+		SetPinValue(NSN_Out, nos::Buffer::From(out));
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterTrackToTransformQ(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.graphics.TrackToTransformQ"), TrackToTransformQNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+}  // namespace nos::graphics

--- a/Plugins/nosGraphics/Source/TrackToView.cpp
+++ b/Plugins/nosGraphics/Source/TrackToView.cpp
@@ -1,0 +1,93 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosTrack/Track_generated.h>
+#include <nosGraphics/Graphics_generated.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtx/euler_angles.hpp>
+
+namespace nos::graphics
+{
+glm::mat4 MakeView(glm::vec3 pos, glm::vec3 rot)
+{
+	rot = glm::radians(rot);
+	auto mat = (glm::mat3)glm::eulerAngleZYX(rot.z, -rot.y, -rot.x);
+	return glm::lookAtLH(pos, pos + mat[0], mat[2]);
+}
+
+glm::mat4 Perspective(float fovx, float aspectRatio, glm::vec2 projectionShift, glm::vec2 clipPlanes)
+{
+	const f32 X = 1.f / tanf(glm::radians(fovx * 0.5f));
+	const f32 Y = -X * aspectRatio;
+	const f32 Z = clipPlanes.y / (clipPlanes.y - clipPlanes.x);
+	return glm::mat4(glm::vec4(X, 0, 0, 0),
+					 glm::vec4(0, Y, 0, 0),
+					 glm::vec4(projectionShift.x, projectionShift.y, Z, 1.0f),
+					 glm::vec4(0, 0, -clipPlanes.x * Z, 0));
+}
+
+glm::vec2 CalculateProjectionShift(glm::vec2 sensorSize, glm::vec2 centerShift)
+{
+	if (centerShift == glm::vec2(0))
+		return glm::vec2(0);
+	if (sensorSize == glm::vec2(0))
+		sensorSize = glm::vec2(1);
+	auto projectionShift = glm::vec2(-centerShift / sensorSize);
+	projectionShift.y = -projectionShift.y;
+	return projectionShift;
+}
+
+NOS_REGISTER_NAME(Track)
+NOS_REGISTER_NAME(Clip)
+NOS_REGISTER_NAME(View)
+struct TrackToView : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+		nos::track::TTrack const& track = pins.GetPinValue<nos::track::TTrack>(NSN_Track);
+		nos::fb::vec2 clip = *pins.GetPinValue<nos::fb::vec2>(NSN_Clip);
+
+		glm::vec2 sensorSize = reinterpret_cast<glm::vec2 const&>(track.sensor_size);
+		glm::vec2 centerShift = reinterpret_cast<glm::vec2 const&>(track.lens_distortion.center_shift());
+		glm::vec2 projShift = CalculateProjectionShift(sensorSize, centerShift);
+		if (glm::vec2(0) == sensorSize)
+		{
+			sensorSize = glm::vec2(1);
+		}
+		float aspectRatio = sensorSize.x / sensorSize.y * track.pixel_aspect_ratio;
+		TPerspectiveProjection perspectiveProjection{};
+		perspectiveProjection.aspect_ratio = aspectRatio;
+		perspectiveProjection.fov_x = track.fov;
+		TProjection projection{};
+		projection.clip_planes = clip;
+		projection.center_shift = reinterpret_cast<nos::fb::vec2 const&>(centerShift);
+		projection.projection_type = ProjectionType::Perspective;
+		projection.perspective = std::make_unique<TPerspectiveProjection>(perspectiveProjection);
+		glm::mat4 viewMatrix = MakeView(
+			reinterpret_cast<glm::vec3 const&>(track.location),
+										reinterpret_cast<glm::vec3 const&>(track.rotation));
+
+		glm::mat4 projectionMatrix = Perspective(
+			track.fov, aspectRatio, centerShift, reinterpret_cast<glm::vec2 const&>(clip));
+
+		TRenderView view{};
+		view.projection = std::make_unique<TProjection>(projection);
+		view.view = reinterpret_cast<nos::fb::mat4 const&>(viewMatrix);
+		view.left_handed_projection_matrix = reinterpret_cast<nos::fb::mat4 const&>(projectionMatrix);
+		SetPinValue(NSN_View, Buffer::From(view));
+		return NOS_RESULT_SUCCESS;
+	}
+
+	static nosResult OnRegister() { return NOS_RESULT_SUCCESS; }
+};
+
+nosResult RegisterTrackToView(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("TrackToView"), TrackToView, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::graphics

--- a/Plugins/nosGraphics/Tests/TrackToTransformQ_Identity_Parity.nosa
+++ b/Plugins/nosGraphics/Tests/TrackToTransformQ_Identity_Parity.nosa
@@ -1,0 +1,503 @@
+{
+  "info": {
+    "version": "1.4.0.b0",
+    "loaded_modules": [
+      {
+        "name": "nos.test",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nos.reflect",
+        "version": "3.0.0"
+      },
+      {
+        "name": "nos.graphics",
+        "version": "0.5.0"
+      }
+    ]
+  },
+  "graph": {
+    "id": "a18e8b0c-1c28-4082-a6c9-3c01e4c7945d",
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "contents_type": "Graph",
+    "contents": {
+      "nodes": [
+        {
+          "id": "9d32967d-ea68-4a7a-9248-df7674c2ff72",
+          "name": "Thread",
+          "class_name": "nos.Thread",
+          "pins": [
+            {
+              "id": "87f7f0e3-52a4-446f-a7db-6fcf4d8422a2",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "live": true
+            },
+            {
+              "id": "ddd80fbe-be24-4c23-ada3-ec45baad4611",
+              "name": "Importance",
+              "type_name": "ulong",
+              "show_as": "PROPERTY",
+              "can_show_as": "PROPERTY_ONLY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 86,
+            "y": -94
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          },
+          "always_execute": true
+        },
+        {
+          "id": "ec6cbba6-7413-46c9-bbfa-a24148800655",
+          "name": "TestScheduler",
+          "class_name": "nos.test.TestScheduler",
+          "pins": [
+            {
+              "id": "f97c713b-ee2c-4e87-93b5-3cb9d77f0a4e",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "f1371c0f-f252-4e00-95fc-e360306f47b7",
+              "name": "Sink",
+              "type_name": "uint",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "fd53adf3-6280-41a6-aa6b-5b56a5e2ebf8",
+              "name": "FreeRun",
+              "type_name": "bool",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": false,
+              "def": false,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "28a8823a-b240-4fd1-af5e-6dc756b142e8",
+              "name": "DeltaTime",
+              "type_name": "nos.fb.vec2u",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 1,
+                "y": 60
+              },
+              "def": {
+                "x": 1,
+                "y": 60
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 324,
+            "y": 7
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "de7ad34d-d2ac-4387-a959-3ac150355dd7",
+          "name": "Assert",
+          "class_name": "nos.test.Assert",
+          "pins": [
+            {
+              "id": "698c6390-5c12-41a4-bb29-d5d7285ac2c3",
+              "name": "Behaviour",
+              "type_name": "nos.test.AssertionBehaviour",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "EXIT_WITH_STATUS_CODE",
+              "def": "EXIT_WITH_STATUS_CODE",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "5ddf38d0-3bca-4821-9c60-8bdaa12d4531",
+              "name": "NumFramesToWait",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "aaf9d12a-1ab7-4d4c-8a9c-6e2daa20cdf7",
+              "name": "FrameCount",
+              "type_name": "uint",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "4949797f-5639-404e-abcb-15d3853d154c",
+              "name": "Condition",
+              "type_name": "bool",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "ddb090ff-945a-4cb5-aa4b-cf52f508e005",
+              "name": "NumFramesToAssertOver",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "min": 1
+            }
+          ],
+          "pos": {
+            "x": 93,
+            "y": 11
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "55de3cdc-ec06-42aa-ba6b-b7a9d81473fa",
+          "name": "IsEqual",
+          "class_name": "nos.reflect.IsEqual",
+          "pins": [
+            {
+              "id": "93af78ff-baed-434e-9b3b-babec9371555",
+              "name": "A",
+              "type_name": "nos.track.TransformQ",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0,
+                  "w": 1.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "def": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0,
+                  "w": 1.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "066d2721-77b5-416d-9760-633c48428efc",
+              "name": "B",
+              "type_name": "nos.track.TransformQ",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0,
+                  "w": 1.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "def": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0,
+                  "w": 1.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "d81bec80-6622-4b10-b344-6801d04d1416",
+              "name": "IsEqual",
+              "type_name": "bool",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -105,
+            "y": 4
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "id": "e6793293-d191-4804-819a-f1b82c9663b9",
+          "name": "TrackToTransformQ",
+          "class_name": "nos.graphics.TrackToTransformQ",
+          "pins": [
+            {
+              "id": "31f45aa9-f88a-41b6-9300-2264b2e7356c",
+              "name": "Track",
+              "type_name": "nos.track.Track",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "location": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                }
+              },
+              "def": {
+                "location": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                }
+              }
+            },
+            {
+              "id": "0f3ba1fd-bd2a-4042-a99f-48d67381d5af",
+              "name": "Frame",
+              "type_name": "nos.track.CoordinateFrame",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "up": "PosZ",
+                "forward": "PosX",
+                "handedness": "LeftHanded",
+                "euler": {
+                  "order": "ZYX",
+                  "sign_x": -1,
+                  "sign_y": -1,
+                  "sign_z": 1
+                },
+                "meters_per_unit": 0.01
+              },
+              "def": {
+                "up": "PosZ",
+                "forward": "PosX",
+                "handedness": "LeftHanded",
+                "euler": {
+                  "order": "ZYX",
+                  "sign_x": -1,
+                  "sign_y": -1,
+                  "sign_z": 1
+                },
+                "meters_per_unit": 0.01
+              }
+            },
+            {
+              "id": "d7e7bf02-6c91-4f71-8ff5-81c1ea37a43d",
+              "name": "Out",
+              "type_name": "nos.track.TransformQ",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -266,
+            "y": 14
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "from": "87f7f0e3-52a4-446f-a7db-6fcf4d8422a2",
+          "to": "f97c713b-ee2c-4e87-93b5-3cb9d77f0a4e",
+          "id": "d4931938-434b-49d9-aee4-8da2ba610b61"
+        },
+        {
+          "from": "aaf9d12a-1ab7-4d4c-8a9c-6e2daa20cdf7",
+          "to": "f1371c0f-f252-4e00-95fc-e360306f47b7",
+          "id": "ae149eb4-fcc8-4208-92fd-bafbcbf77f7f"
+        },
+        {
+          "from": "d81bec80-6622-4b10-b344-6801d04d1416",
+          "to": "4949797f-5639-404e-abcb-15d3853d154c",
+          "id": "b4040e44-09c6-409a-b7b3-902b0d9f1c1f"
+        },
+        {
+          "from": "d7e7bf02-6c91-4f71-8ff5-81c1ea37a43d",
+          "to": "93af78ff-baed-434e-9b3b-babec9371555",
+          "id": "52a09a7c-4c09-486c-93e5-cdd11f6251e2"
+        }
+      ]
+    },
+    "plugin_version": {
+      "major": 0,
+      "minor": 0,
+      "patch": 0
+    }
+  }
+}

--- a/Plugins/nosGraphics/Types/CoordinateSystemPresets.json
+++ b/Plugins/nosGraphics/Types/CoordinateSystemPresets.json
@@ -1,0 +1,49 @@
+{
+    "name": "nos.graphics.CoordinateSystemPresets",
+    "values": [
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "Unreal"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "OpenGL-glTF"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "NegY", "forward": "PosZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "OpenCV-COLMAP"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "PosZ", "handedness": "LeftHanded", "euler": { "order": "ZXY", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Unity"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "Maya"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Houdini"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "PosY", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "3dsMax"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "NegY", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Blender"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "value_name": "Custom"
+        }
+    ]
+}

--- a/Plugins/nosGraphics/Types/Graphics.fbs
+++ b/Plugins/nosGraphics/Types/Graphics.fbs
@@ -1,0 +1,43 @@
+include "Common.fbs";
+
+namespace nos.graphics;
+
+// NOTE: The coordinate-system / transform types (CoordinateFrame, SignedAxis,
+// Handedness, EulerOrder, EulerEncoding, Transform, TransformQ, AlignmentState,
+// TransformGuidance) live in nos.track (Types/Coordinates.fbs, same nos.graphics
+// namespace) to avoid a circular nos.graphics<->nos.track plugin dependency.
+// Include <nosTrack/Coordinates_generated.h> for those.
+
+table PerspectiveProjection
+{
+	aspect_ratio: float;
+	fov_x: float;
+}
+
+table OrthographicProjection
+{
+	width: float;
+	height: float;
+}
+
+enum ProjectionType : ubyte
+{
+	Perspective,
+	Orthographic
+}
+
+table Projection
+{
+	clip_planes: nos.fb.vec2 (native_inline);
+	center_shift: nos.fb.vec2 (native_inline);
+	projection_type: ProjectionType;
+	perspective: PerspectiveProjection;
+	orthographic: OrthographicProjection;
+}
+
+table RenderView
+{
+	view: nos.fb.mat4(native_inline);
+	left_handed_projection_matrix: nos.fb.mat4(native_inline);
+	projection: Projection;
+}

--- a/Plugins/nosMath/Math.nosplugin
+++ b/Plugins/nosMath/Math.nosplugin
@@ -2,7 +2,7 @@
 	"info": {
 		"id": {
 			"name": "nos.math",
-      "version": "2.0.0"
+      "version": "2.1.0"
 		},
 		"description": "Nodes for math operations.",
 		"display_name": "Math",

--- a/Plugins/nosMath/Nodes/EmbedMat3ToMat4.nosnode
+++ b/Plugins/nosMath/Nodes/EmbedMat3ToMat4.nosnode
@@ -1,0 +1,1140 @@
+{ "nodes": [
+    {
+      "class_name": "nos.math.EmbedMat3ToMat4",
+			"menu_info": {
+				"category": "Math",
+				"display_name": "Embed mat3 to mat4"
+			},
+      "node": {
+        "id": "99be7fe5-a8c1-4009-ac6b-4762bbc89c20",
+        "name": "EmbedMat3ToMat4",
+        "display_name": "Embed mat3 to mat4",
+        "class_name": "nos.math.EmbedMat3ToMat4",
+        "pins": [
+          {
+            "id": "47c7aef0-c6e0-47f3-841a-842f153cbe27",
+            "name": "Input",
+            "type_name": "nos.fb.mat3",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "646238ca-2b8b-4f00-a01d-76415b84c677" }
+          },
+          {
+            "id": "2b381f1a-4dcc-470e-aa31-caeba1fec13e",
+            "name": "Output",
+            "type_name": "nos.fb.mat4",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_ONLY",
+            "visualizer": {
+            },
+            "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 } },
+            "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "65104ee3-bcbc-4340-ab5c-78cff2383a1a" }
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "fbdc3402-595c-4aac-925c-b1600d35b5c4",
+              "name": "Make (3)",
+              "class_name": "nos.reflect.Make",
+              "pins": [
+                {
+                  "id": "dea52951-863a-4712-8cf4-18bcd6519b2e",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "display_name": "nos.fb.mat4"
+                },
+                {
+                  "id": "faddf5c0-d610-46e0-a306-6fa90fba857f",
+                  "name": "x",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "04aa5cea-cb59-40a9-b8de-3bb702c1da25",
+                  "name": "y",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "c133f1ed-8529-4ea0-bc48-d136ad38ca84",
+                  "name": "z",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "0efd44a0-b21d-49ac-9adf-24d163688e01",
+                  "name": "w",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 563.0, "y": 548.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "template_parameters": [
+                { "name": "Type", "type_name": "string", "value": "nos.fb.mat4" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "38698c71-8e0f-41b3-a3c7-4dc7f08b31ac",
+              "name": "Break (1)",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "2250f967-ee85-4d6e-9d13-ada81e899aba",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "06ee7b7f-8e6b-43a4-9c02-b8bde50f41b4",
+                  "name": "x",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "63d04325-6579-4a68-8a78-81e8ed4c9150",
+                  "name": "y",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "144e1eb0-0707-4a18-8f40-91c883ef4147",
+                  "name": "z",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.462518, "y": 0.208051, "z": 1.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 82.0, "y": 548.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Break nos.fb.mat3",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "d1205902-aba1-43d1-be4b-f414ef190e2c",
+              "name": "Input",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "f709f07f-bb00-45be-a414-77219a3fb65b",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "646238ca-2b8b-4f00-a01d-76415b84c677",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0 } },
+                  "referred_by": [
+                    "47c7aef0-c6e0-47f3-841a-842f153cbe27"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -156.5, "y": 534.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "mat3",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "7a8728f7-8f87-42ff-b216-85fb12b5e1ea",
+              "name": "vec3 to vec4 (1)",
+              "class_name": "nos.math.Vec3ToVec4",
+              "pins": [
+                {
+                  "id": "181b0a87-5008-4dfe-88cb-5b3f34f651da",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "77dfeab8-caa9-4bad-b52c-b2a03dab88a9" }
+                },
+                {
+                  "id": "1d261407-a24e-42fd-ab9a-a435c34f66fa",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "74daa2db-ad90-4b58-9682-c5ca625a5a05" },
+                  "connection_conditions": "!array"
+                }
+              ],
+              "pos": { "x": 325.0, "y": 550.0 },
+              "contents_type": "Graph",
+              "contents": { "nodes": [
+                  {
+                    "id": "bfa4f366-ca42-49bd-af80-befbe4193cbf",
+                    "name": "Break (3)",
+                    "class_name": "nos.reflect.Break",
+                    "pins": [
+                      {
+                        "id": "43f6d279-988d-4c87-94e2-8ce60ec97c91",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "fd66aa42-53ce-49b1-a28f-88c59ba3be5e",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.036203,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "1ecdc8ef-17c6-452f-a8f7-b7d550ac83c3",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.210621,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "926f9d12-7051-4bff-a743-953e1809c6d1",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.072404,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 171.0, "y": 354.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Break nos.fb.vec3",
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "87e88e40-b9cd-44a5-8e13-30ae0bfef20e",
+                    "name": "Output",
+                    "class_name": "nos.internal.GraphOutput",
+                    "pins": [
+                      {
+                        "id": "c85d4178-b90d-4a52-a6c4-a60e1859edd8",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "74daa2db-ad90-4b58-9682-c5ca625a5a05",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 },
+                        "referred_by": [
+                          "1d261407-a24e-42fd-ab9a-a435c34f66fa"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      }
+                    ],
+                    "pos": { "x": 570.0, "y": 353.5 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "5f5d7cd7-0b93-4cd2-ae31-7cbaa0571379",
+                    "name": "Make (4)",
+                    "class_name": "nos.reflect.MakeDynamic",
+                    "pins": [
+                      {
+                        "id": "13510b70-935d-43f2-8e11-55a3956787e3",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "2237b297-3c5c-43d4-b31b-147ef74b967c",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.036203,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "ef3f55b1-5b03-4e2b-95ed-b9c2138148e3",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.210621,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "af4f92c1-2f34-45f5-9f31-cd7da20ddf1c",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.072404,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "79955d5d-d076-4ad3-be44-d9daf6758011",
+                        "name": "w",
+                        "type_name": "float",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 370.0, "y": 353.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "template_parameters": [
+                      { "name": "Type", "type_name": "string", "value": "nos.fb.vec4" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "73be4295-5883-4110-8e38-804c568ed3ff",
+                    "name": "Input",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "4c41a111-b594-45ff-ba3d-1ec089a972b8",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "77dfeab8-caa9-4bad-b52c-b2a03dab88a9",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.036203, "y": 0.210621, "z": 0.072404 },
+                        "referred_by": [
+                          "181b0a87-5008-4dfe-88cb-5b3f34f651da"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": -29.0, "y": 353.5 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  }
+                ], "connections": [
+                  { "from": "1ecdc8ef-17c6-452f-a8f7-b7d550ac83c3", "to": "ef3f55b1-5b03-4e2b-95ed-b9c2138148e3", "id": "74e51fce-b751-4b8b-9f20-494db9e22888" },
+                  { "from": "926f9d12-7051-4bff-a743-953e1809c6d1", "to": "af4f92c1-2f34-45f5-9f31-cd7da20ddf1c", "id": "3f8be45c-bc45-4bc3-86fd-d16486a60a24" },
+                  { "from": "fd66aa42-53ce-49b1-a28f-88c59ba3be5e", "to": "2237b297-3c5c-43d4-b31b-147ef74b967c", "id": "161bbc27-9df8-47e2-9325-8d7a81cce82d" },
+                  { "from": "4c41a111-b594-45ff-ba3d-1ec089a972b8", "to": "43f6d279-988d-4c87-94e2-8ce60ec97c91", "id": "f6f68f3f-975e-4c37-8bf8-4030c2a7dc0a" },
+                  { "from": "13510b70-935d-43f2-8e11-55a3956787e3", "to": "c85d4178-b90d-4a52-a6c4-a60e1859edd8", "id": "2fbe9a78-3052-407a-93f7-a0224a67e500" }
+                ] },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "e7f11c0c-414c-4e17-855b-c9f9cd788cd6",
+              "name": "vec3 to vec4",
+              "class_name": "nos.math.Vec3ToVec4",
+              "pins": [
+                {
+                  "id": "cdbbd98e-d192-4b02-8fdb-6cb00c9c2953",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "e5c81a73-91a1-4d3b-8e7f-52bd87d15dbc" }
+                },
+                {
+                  "id": "535234d0-d437-46fb-82ce-3482cca6f7b1",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "f6ffa645-aed5-4292-be21-a1a9d0a27312" },
+                  "connection_conditions": "!array"
+                }
+              ],
+              "pos": { "x": 321.0, "y": 466.0 },
+              "contents_type": "Graph",
+              "contents": { "nodes": [
+                  {
+                    "id": "b40cf951-6535-40f7-aff2-f561f385aa4b",
+                    "name": "Break (3)",
+                    "class_name": "nos.reflect.Break",
+                    "pins": [
+                      {
+                        "id": "d1b47f41-8eab-444f-b995-f8548231a066",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "3b96acde-94ed-4970-9c41-777938861adf",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.11176,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "8a250dcb-6631-409e-99c1-bb676cd46e5e",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.000971,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "55aed1e5-37df-4d43-bcc2-6435d59f9184",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -0.003155,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 171.0, "y": 354.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Break nos.fb.vec3",
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "7b1c284b-7a41-4c58-bc83-d61283d0bc95",
+                    "name": "Make (4)",
+                    "class_name": "nos.reflect.MakeDynamic",
+                    "pins": [
+                      {
+                        "id": "a6d7694c-fe88-4164-bf43-eb08f9cb3524",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "2c5f637d-f900-4ec1-b261-cef6d8d28716",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.11176,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "67b693c7-41ab-4c05-9f09-221008c42d93",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.000971,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "55490ec5-1213-4108-9d41-17d927fa9bb1",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": -0.003155,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "267159a3-6bb6-4027-a5b2-07a5e1ec0cef",
+                        "name": "w",
+                        "type_name": "float",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 370.0, "y": 353.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "template_parameters": [
+                      { "name": "Type", "type_name": "string", "value": "nos.fb.vec4" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "bf8c9cb4-9ee2-4200-887c-5c390e644cd7",
+                    "name": "Input",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "3db7336f-e4f6-439b-826b-631704ab00b3",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "e5c81a73-91a1-4d3b-8e7f-52bd87d15dbc",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155 },
+                        "referred_by": [
+                          "cdbbd98e-d192-4b02-8fdb-6cb00c9c2953"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": -29.0, "y": 353.5 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "a20340d0-c0ce-4788-b212-2d8414f48918",
+                    "name": "Output",
+                    "class_name": "nos.internal.GraphOutput",
+                    "pins": [
+                      {
+                        "id": "e4554707-4237-4d10-b595-43209369450e",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "f6ffa645-aed5-4292-be21-a1a9d0a27312",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 },
+                        "referred_by": [
+                          "535234d0-d437-46fb-82ce-3482cca6f7b1"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      }
+                    ],
+                    "pos": { "x": 570.0, "y": 353.5 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  }
+                ], "connections": [
+                  { "from": "8a250dcb-6631-409e-99c1-bb676cd46e5e", "to": "67b693c7-41ab-4c05-9f09-221008c42d93", "id": "bc71b1dc-d726-491a-ba7f-36933afc7525" },
+                  { "from": "3b96acde-94ed-4970-9c41-777938861adf", "to": "2c5f637d-f900-4ec1-b261-cef6d8d28716", "id": "a168b885-270c-4460-a22c-64fdc5935136" },
+                  { "from": "55aed1e5-37df-4d43-bcc2-6435d59f9184", "to": "55490ec5-1213-4108-9d41-17d927fa9bb1", "id": "802fd8a2-f819-43ee-af45-7eaf1b9a8e44" },
+                  { "from": "3db7336f-e4f6-439b-826b-631704ab00b3", "to": "d1b47f41-8eab-444f-b995-f8548231a066", "id": "ece3cfd3-7034-4431-91be-87837beb357d" },
+                  { "from": "a6d7694c-fe88-4164-bf43-eb08f9cb3524", "to": "e4554707-4237-4d10-b595-43209369450e", "id": "93da2d46-94e3-4970-8792-3ce18c4ab031" }
+                ] },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "54633faf-55fe-4ba4-8918-cee3002dab0f",
+              "name": "vec3 to vec4 (2)",
+              "class_name": "nos.math.Vec3ToVec4",
+              "pins": [
+                {
+                  "id": "7ff026b9-34cc-486d-b92e-d065170f66b8",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.462518, "y": 0.208051, "z": 1.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "bb296f28-0982-4897-a35c-05d4c2c1e096" }
+                },
+                {
+                  "id": "c97903f5-24b6-4e20-a214-9ac6d210b752",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "PortalPin",
+                  "contents": { "source_id": "d09718fb-33bb-41a1-81cd-8264a8fa0786" },
+                  "connection_conditions": "!array"
+                }
+              ],
+              "pos": { "x": 326.0, "y": 635.0 },
+              "contents_type": "Graph",
+              "contents": { "nodes": [
+                  {
+                    "id": "f21d48f0-1f0f-4b3c-bb97-02d85474fb83",
+                    "name": "Break (3)",
+                    "class_name": "nos.reflect.Break",
+                    "pins": [
+                      {
+                        "id": "80891249-2b4e-4f81-891c-0a5164d6605d",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.462518, "y": 0.208051, "z": 1.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "921e347d-5bcc-4ea3-a77b-3024ab1c8a88",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.462518,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "3c9a9f1c-89de-46ed-9297-692e7e454b98",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.208051,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "15d6b37c-6faf-465d-a258-a19264004d25",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 1.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 171.0, "y": 354.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "display_name": "Break nos.fb.vec3",
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "743bbd05-7364-4b51-b560-7f1bd7daab3d",
+                    "name": "Make (4)",
+                    "class_name": "nos.reflect.MakeDynamic",
+                    "pins": [
+                      {
+                        "id": "3105027b-e589-449c-8023-2d8ee6079ea0",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "6fcb61e7-8106-459e-875f-4d19b47ffcee",
+                        "name": "x",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.462518,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "f24b12af-5cc2-4700-b5dd-582c2b9f6398",
+                        "name": "y",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.208051,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "39dd23a7-f074-4a49-ad1e-5c3c5bf088f2",
+                        "name": "z",
+                        "type_name": "float",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 1.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "355f0699-d36b-4800-a30f-56f15366b812",
+                        "name": "w",
+                        "type_name": "float",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": 0.0,
+                        "def": 0.0,
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": 370.0, "y": 353.0 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "template_parameters": [
+                      { "name": "Type", "type_name": "string", "value": "nos.fb.vec4" }
+                    ],
+                    "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+                  },
+                  {
+                    "id": "c0238456-acbb-4840-932a-497a5a299802",
+                    "name": "Input",
+                    "class_name": "nos.internal.GraphInput",
+                    "pins": [
+                      {
+                        "id": "493e37d8-e356-42eb-b265-f751b2292ef1",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.462518, "y": 0.208051, "z": 1.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      },
+                      {
+                        "id": "bb296f28-0982-4897-a35c-05d4c2c1e096",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec3",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.462518, "y": 0.208051, "z": 1.0 },
+                        "referred_by": [
+                          "7ff026b9-34cc-486d-b92e-d065170f66b8"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { }
+                      }
+                    ],
+                    "pos": { "x": -29.0, "y": 353.5 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  },
+                  {
+                    "id": "b77bcef9-c906-4649-8eeb-cb4a36fb84f4",
+                    "name": "Output",
+                    "class_name": "nos.internal.GraphOutput",
+                    "pins": [
+                      {
+                        "id": "0d7ab2ef-b7e5-445d-a4c2-495157dca7bc",
+                        "name": "Input",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 },
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      },
+                      {
+                        "id": "d09718fb-33bb-41a1-81cd-8264a8fa0786",
+                        "name": "Output",
+                        "type_name": "nos.fb.vec4",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "visualizer": {
+                        },
+                        "data": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 },
+                        "referred_by": [
+                          "c97903f5-24b6-4e20-a214-9ac6d210b752"
+                        ],
+                        "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                        "meta_data_map": [
+                          { "key": "PinHidden", "value": "true" }
+                        ],
+                        "contents_type": "JobPin",
+                        "contents": { },
+                        "connection_conditions": "!array"
+                      }
+                    ],
+                    "pos": { "x": 570.0, "y": 353.5 },
+                    "contents_type": "Job",
+                    "contents": { "type": "" },
+                    "function_category": "Default Node",
+                    "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+                  }
+                ], "connections": [
+                  { "from": "3c9a9f1c-89de-46ed-9297-692e7e454b98", "to": "f24b12af-5cc2-4700-b5dd-582c2b9f6398", "id": "92ec3ea5-0807-4b90-be24-96c6487d5053" },
+                  { "from": "921e347d-5bcc-4ea3-a77b-3024ab1c8a88", "to": "6fcb61e7-8106-459e-875f-4d19b47ffcee", "id": "004c40eb-03ba-455f-98c9-c50af40b347b" },
+                  { "from": "15d6b37c-6faf-465d-a258-a19264004d25", "to": "39dd23a7-f074-4a49-ad1e-5c3c5bf088f2", "id": "4d6b61f7-23f2-4d4a-b171-0cf13a2a92d7" },
+                  { "from": "493e37d8-e356-42eb-b265-f751b2292ef1", "to": "80891249-2b4e-4f81-891c-0a5164d6605d", "id": "a63f87b1-cea4-4f4e-94bf-5d1814a6ef0c" },
+                  { "from": "3105027b-e589-449c-8023-2d8ee6079ea0", "to": "0d7ab2ef-b7e5-445d-a4c2-495157dca7bc", "id": "c453650a-c8c9-4d93-bac2-317b99f3e01b" }
+                ] },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 1, "minor": 10, "patch": 0 }
+            },
+            {
+              "id": "f7a816aa-f641-489b-ac91-9cfc05291595",
+              "name": "Output",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "925971c9-51b0-4c81-b671-daad280ef242",
+                  "name": "Input",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 } },
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "65104ee3-bcbc-4340-ab5c-78cff2383a1a",
+                  "name": "Output",
+                  "type_name": "nos.fb.mat4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": { "x": 0.11176, "y": 0.000971, "z": -0.003155, "w": 0.0 }, "y": { "x": 0.036203, "y": 0.210621, "z": 0.072404, "w": 0.0 }, "z": { "x": 0.462518, "y": 0.208051, "z": 1.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 } },
+                  "referred_by": [
+                    "2b381f1a-4dcc-470e-aa31-caeba1fec13e"
+                  ],
+                  "def": { "x": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "y": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "z": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "w": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 774.0, "y": 530.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "mat4",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "connections": [
+            { "from": "06ee7b7f-8e6b-43a4-9c02-b8bde50f41b4", "to": "cdbbd98e-d192-4b02-8fdb-6cb00c9c2953", "id": "1a4e0282-ade4-4016-91de-3f4e9008f131" },
+            { "from": "144e1eb0-0707-4a18-8f40-91c883ef4147", "to": "7ff026b9-34cc-486d-b92e-d065170f66b8", "id": "5a6aa033-0d26-4f3a-b938-859f92f82496" },
+            { "from": "63d04325-6579-4a68-8a78-81e8ed4c9150", "to": "181b0a87-5008-4dfe-88cb-5b3f34f651da", "id": "f3ad24d3-1a25-480f-b62e-a652bd323705" },
+            { "from": "f709f07f-bb00-45be-a414-77219a3fb65b", "to": "2250f967-ee85-4d6e-9d13-ada81e899aba", "id": "8eb8c4f9-1165-47e3-b749-90600422d310" },
+            { "from": "1d261407-a24e-42fd-ab9a-a435c34f66fa", "to": "04aa5cea-cb59-40a9-b8de-3bb702c1da25", "id": "34928e22-1cf9-4745-acab-b6af5cb879b6" },
+            { "from": "535234d0-d437-46fb-82ce-3482cca6f7b1", "to": "faddf5c0-d610-46e0-a306-6fa90fba857f", "id": "2dfabf3a-d8af-47b5-af09-d24eab427d0e" },
+            { "from": "c97903f5-24b6-4e20-a214-9ac6d210b752", "to": "c133f1ed-8529-4ea0-bc48-d136ad38ca84", "id": "97ec65fa-c4b0-4f34-92a6-3a98ce285ac9" },
+            { "from": "dea52951-863a-4712-8cf4-18bcd6519b2e", "to": "925971c9-51b0-4c81-b671-daad280ef242", "id": "f6ce5e78-a873-4d86-b8ff-16413fbc1a8f" }
+          ] },
+        "function_category": "Default Node",
+        "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosMath/Nodes/EulerToQuaternion.nosnode
+++ b/Plugins/nosMath/Nodes/EulerToQuaternion.nosnode
@@ -1,0 +1,38 @@
+{
+	"nodes": [
+		{
+			"class_name": "EulerToQuaternion",
+			"menu_info": {
+				"category": "Math|Linear Algebra",
+				"display_name": "Euler To Quaternion"
+			},
+			"node": {
+				"class_name": "EulerToQuaternion",
+				"contents_type": "Job",
+				"description": "Converts an Euler-angle rotation (degrees) to a unit quaternion (x, y, z, w). The Order pin selects the intrinsic rotation order applied to the components of the input vec3 (e.g. ZYX means R = Rz(rot.z) * Ry(rot.y) * Rx(rot.x)). Default ZYX matches the FreeD/Track convention.",
+				"pins": [
+					{
+						"name": "Euler",
+						"type_name": "nos.fb.vec3d",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Order",
+						"type_name": "nos.math.EulerOrder",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": "ZYX",
+						"description": "Euler intrinsic rotation order applied to the (rot.x, rot.y, rot.z) components."
+					},
+					{
+						"name": "Quaternion",
+						"type_name": "nos.fb.vec4d",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosMath/Nodes/QuaternionMultiply.nosnode
+++ b/Plugins/nosMath/Nodes/QuaternionMultiply.nosnode
@@ -1,0 +1,36 @@
+{
+	"nodes": [
+		{
+			"class_name": "QuaternionMultiply",
+			"menu_info": {
+				"category": "Math|Linear Algebra",
+				"display_name": "Quaternion Multiply"
+			},
+			"node": {
+				"class_name": "QuaternionMultiply",
+				"contents_type": "Job",
+				"description": "Hamilton product of two unit quaternions: Result = A * B (each as (x, y, z, w)). Composing rotations: A * B applies B first, then A. To rotate (conjugate) a quaternion Q by R, compute R * Q * conjugate(R).",
+				"pins": [
+					{
+						"name": "A",
+						"type_name": "nos.fb.vec4d",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "B",
+						"type_name": "nos.fb.vec4d",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Result",
+						"type_name": "nos.fb.vec4d",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosMath/Nodes/QuaternionToEuler.nosnode
+++ b/Plugins/nosMath/Nodes/QuaternionToEuler.nosnode
@@ -1,0 +1,38 @@
+{
+	"nodes": [
+		{
+			"class_name": "QuaternionToEuler",
+			"menu_info": {
+				"category": "Math|Linear Algebra",
+				"display_name": "Quaternion To Euler"
+			},
+			"node": {
+				"class_name": "QuaternionToEuler",
+				"contents_type": "Job",
+				"description": "Converts a unit quaternion (x, y, z, w) to Euler angles (degrees). The Order pin selects the intrinsic rotation order extracted (e.g. ZYX yields rot.z = first rotation about Z, rot.y about Y, rot.x about X). Inverse of EulerToQuaternion when the same Order is used on both ends.",
+				"pins": [
+					{
+						"name": "Quaternion",
+						"type_name": "nos.fb.vec4d",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Order",
+						"type_name": "nos.math.EulerOrder",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": "ZYX",
+						"description": "Euler intrinsic rotation order extracted into the (rot.x, rot.y, rot.z) output components."
+					},
+					{
+						"name": "Euler",
+						"type_name": "nos.fb.vec3d",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosMath/Nodes/Vec3ToVec4.nosnode
+++ b/Plugins/nosMath/Nodes/Vec3ToVec4.nosnode
@@ -1,0 +1,291 @@
+{ "nodes": [
+    {
+      "class_name": "nos.math.Vec3ToVec4",
+			"menu_info": {
+				"category": "Math",
+				"display_name": "vec3 to vec4"
+			},
+      "node": {
+        "id": "5d7df924-f66d-4b4f-b643-3fee50b8969a",
+        "name": "vec3 to vec4",
+        "class_name": "nos.math.Vec3ToVec4",
+        "pins": [
+          {
+            "id": "7e84db7f-fcb2-4761-9cca-a176db039d6a",
+            "name": "Input",
+            "type_name": "nos.fb.vec3",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167 },
+            "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "bec5c71d-364a-4084-9429-e0f9988e5c6b" }
+          },
+          {
+            "id": "121837f4-7aef-454e-b61e-ba1b0b832c86",
+            "name": "Output",
+            "type_name": "nos.fb.vec4",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_ONLY",
+            "visualizer": {
+            },
+            "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167, "w": 0.0 },
+            "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "ea09896b-2b2c-41f9-91d6-80abdafa669b" },
+            "connection_conditions": "!array"
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "7b06254e-25e7-47d0-bc8d-566b5210445f",
+              "name": "Break (3)",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "e7772a58-8a86-46b5-90f4-6b24756ddca0",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "8346189b-b226-468e-afe3-c4be7ec52ac3",
+                  "name": "x",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.005067,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "323d3746-9d50-4ed3-8f85-211743f5ad57",
+                  "name": "y",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -0.030323,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "b4a81cfd-d34e-44f3-9750-b9b6e57e8524",
+                  "name": "z",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.06167,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 171.0, "y": 354.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Break nos.fb.vec3",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "b7617e05-081c-4cb0-b47b-2e9d2c6479c6",
+              "name": "Make (4)",
+              "class_name": "nos.reflect.MakeDynamic",
+              "pins": [
+                {
+                  "id": "3c3772bc-6630-426c-b732-d97be76dd987",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "a14ddcf3-3241-4ddc-bff6-8a8a9296c8bc",
+                  "name": "x",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.005067,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "315b167b-78ec-47ff-a46f-7181f9d49994",
+                  "name": "y",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": -0.030323,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "d1688a14-5057-437e-9994-121ba8c59564",
+                  "name": "z",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.06167,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "98f99f19-e66c-40d3-b38c-f26854f83856",
+                  "name": "w",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 370.0, "y": 353.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "template_parameters": [
+                { "name": "Type", "type_name": "string", "value": "nos.fb.vec4" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "8c66d7d2-d1ce-4b19-9eab-40d927d06aa9",
+              "name": "Input",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "e7457010-80a6-4470-b259-aa1d5d8ae17d",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "bec5c71d-364a-4084-9429-e0f9988e5c6b",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167 },
+                  "referred_by": [
+                    "7e84db7f-fcb2-4761-9cca-a176db039d6a"
+                  ],
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -29.0, "y": 353.5 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "525411f8-1b2d-4b8d-a49f-8aaa606d8616",
+              "name": "Output",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "2d1a1c27-b633-426e-962c-b8d17a37d8ef",
+                  "name": "Input",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "ea09896b-2b2c-41f9-91d6-80abdafa669b",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec4",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.005067, "y": -0.030323, "z": 0.06167, "w": 0.0 },
+                  "referred_by": [
+                    "121837f4-7aef-454e-b61e-ba1b0b832c86"
+                  ],
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                }
+              ],
+              "pos": { "x": 570.0, "y": 353.5 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "connections": [
+            { "from": "323d3746-9d50-4ed3-8f85-211743f5ad57", "to": "315b167b-78ec-47ff-a46f-7181f9d49994", "id": "c7d73992-6f38-4be3-bf56-c4447e304cac" },
+            { "from": "8346189b-b226-468e-afe3-c4be7ec52ac3", "to": "a14ddcf3-3241-4ddc-bff6-8a8a9296c8bc", "id": "c0152fe6-e001-4045-b744-c231f173abb7" },
+            { "from": "b4a81cfd-d34e-44f3-9750-b9b6e57e8524", "to": "d1688a14-5057-437e-9994-121ba8c59564", "id": "9984fb4a-c3f6-4796-aac8-0c9541b7fdc5" },
+            { "from": "e7457010-80a6-4470-b259-aa1d5d8ae17d", "to": "e7772a58-8a86-46b5-90f4-6b24756ddca0", "id": "294b1711-e503-4d38-87c9-bd3f97d7379d" },
+            { "from": "3c3772bc-6630-426c-b732-d97be76dd987", "to": "2d1a1c27-b633-426e-962c-b8d17a37d8ef", "id": "94fde0ea-6c8f-4a2c-a731-d6d3eadbf6b4" }
+          ] },
+        "function_category": "Default Node",
+        "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosMath/Source/EulerToQuaternion.cpp
+++ b/Plugins/nosMath/Source/EulerToQuaternion.cpp
@@ -1,0 +1,90 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosMath/Math_generated.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <glm/gtx/euler_angles.hpp>
+
+namespace nos::math
+{
+
+// Build a rotation matrix for the given intrinsic Euler order.
+// In all cases, rot.x is the angle about X, rot.y about Y, rot.z about Z (radians).
+// Order ZYX means R = Rz(rot.z) * Ry(rot.y) * Rx(rot.x), applied right-to-left to a point.
+static glm::dmat4 EulerToMat(EulerOrder order, glm::dvec3 const& r)
+{
+	switch (order)
+	{
+	case EulerOrder::ZYX: return glm::eulerAngleZYX<double>(r.z, r.y, r.x);
+	case EulerOrder::XYZ: return glm::eulerAngleXYZ<double>(r.x, r.y, r.z);
+	case EulerOrder::YXZ: return glm::eulerAngleYXZ<double>(r.y, r.x, r.z);
+	case EulerOrder::YZX: return glm::eulerAngleYZX<double>(r.y, r.z, r.x);
+	case EulerOrder::ZXY: return glm::eulerAngleZXY<double>(r.z, r.x, r.y);
+	case EulerOrder::XZY: return glm::eulerAngleXZY<double>(r.x, r.z, r.y);
+	}
+	return glm::dmat4(1.0);
+}
+
+static void MatToEuler(EulerOrder order, glm::dmat4 const& m, glm::dvec3& r)
+{
+	switch (order)
+	{
+	case EulerOrder::ZYX: glm::extractEulerAngleZYX(m, r.z, r.y, r.x); break;
+	case EulerOrder::XYZ: glm::extractEulerAngleXYZ(m, r.x, r.y, r.z); break;
+	case EulerOrder::YXZ: glm::extractEulerAngleYXZ(m, r.y, r.x, r.z); break;
+	case EulerOrder::YZX: glm::extractEulerAngleYZX(m, r.y, r.z, r.x); break;
+	case EulerOrder::ZXY: glm::extractEulerAngleZXY(m, r.z, r.x, r.y); break;
+	case EulerOrder::XZY: glm::extractEulerAngleXZY(m, r.x, r.z, r.y); break;
+	}
+}
+
+struct EulerToQuaternionNodeContext : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+		auto* in = params.GetPinValue<fb::vec3d>(NOS_NAME("Euler"));
+		auto* order = params.GetPinValue<EulerOrder>(NOS_NAME("Order"));
+
+		glm::dvec3 r = glm::radians(glm::dvec3(in->x(), in->y(), in->z()));
+		glm::dquat q(EulerToMat(*order, r));
+
+		nos::fb::vec4d out(q.x, q.y, q.z, q.w);
+		SetPinValue(NOS_NAME("Quaternion"), out);
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+void RegisterEulerToQuaternion(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.math.EulerToQuaternion"), EulerToQuaternionNodeContext, fn)
+}
+
+struct QuaternionToEulerNodeContext : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+		auto* in = params.GetPinValue<fb::vec4d>(NOS_NAME("Quaternion"));
+		auto* order = params.GetPinValue<EulerOrder>(NOS_NAME("Order"));
+
+		glm::dquat q(in->w(), in->x(), in->y(), in->z());
+		glm::dmat4 m = glm::mat4_cast(q);
+		glm::dvec3 r(0.0);
+		MatToEuler(*order, m, r);
+
+		nos::fb::vec3d out(glm::degrees(r.x), glm::degrees(r.y), glm::degrees(r.z));
+		SetPinValue(NOS_NAME("Euler"), out);
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+void RegisterQuaternionToEuler(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.math.QuaternionToEuler"), QuaternionToEulerNodeContext, fn)
+}
+
+}  // namespace nos::math

--- a/Plugins/nosMath/Source/Math.cpp
+++ b/Plugins/nosMath/Source/Math.cpp
@@ -88,6 +88,9 @@ enum class MathNodeTypes : int {
 	Not,
 	Random,
 	SineWave,
+	EulerToQuaternion,
+	QuaternionToEuler,
+	QuaternionMultiply,
 	Count
 };
 
@@ -134,6 +137,9 @@ void RegisterOr(nosNodeFunctions*);
 void RegisterNot(nosNodeFunctions*);
 void RegisterRandom(nosNodeFunctions*);
 void RegisterSineWave(nosNodeFunctions*);
+void RegisterEulerToQuaternion(nosNodeFunctions*);
+void RegisterQuaternionToEuler(nosNodeFunctions*);
+void RegisterQuaternionMultiply(nosNodeFunctions*);
 
 nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outCount, nosNodeFunctions** outList)
 {
@@ -237,6 +243,18 @@ nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outCount, nosNodeFunctions** o
 		}
 		case MathNodeTypes::Random: {
 			RegisterRandom(node);
+			break;
+		}
+		case MathNodeTypes::EulerToQuaternion: {
+			RegisterEulerToQuaternion(node);
+			break;
+		}
+		case MathNodeTypes::QuaternionToEuler: {
+			RegisterQuaternionToEuler(node);
+			break;
+		}
+		case MathNodeTypes::QuaternionMultiply: {
+			RegisterQuaternionMultiply(node);
 			break;
 		}
 		default:

--- a/Plugins/nosMath/Source/QuaternionMultiply.cpp
+++ b/Plugins/nosMath/Source/QuaternionMultiply.cpp
@@ -1,0 +1,35 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosMath/Math_generated.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+namespace nos::math
+{
+
+struct QuaternionMultiplyNodeContext : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+		auto* a = params.GetPinValue<fb::vec4d>(NOS_NAME("A"));
+		auto* b = params.GetPinValue<fb::vec4d>(NOS_NAME("B"));
+
+		glm::dquat qa(a->w(), a->x(), a->y(), a->z());
+		glm::dquat qb(b->w(), b->x(), b->y(), b->z());
+		glm::dquat qr = qa * qb;
+
+		nos::fb::vec4d out(qr.x, qr.y, qr.z, qr.w);
+		SetPinValue(NOS_NAME("Result"), out);
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+void RegisterQuaternionMultiply(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.math.QuaternionMultiply"), QuaternionMultiplyNodeContext, fn)
+}
+
+}  // namespace nos::math

--- a/Plugins/nosMath/Tests/EulerToQuaternion_Identity_Parity.nosa
+++ b/Plugins/nosMath/Tests/EulerToQuaternion_Identity_Parity.nosa
@@ -1,0 +1,419 @@
+{
+  "info": {
+    "version": "1.4.0.b0",
+    "loaded_modules": [
+      {
+        "name": "nos.test",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nos.reflect",
+        "version": "3.0.0"
+      },
+      {
+        "name": "nos.math",
+        "version": "2.1.0"
+      }
+    ]
+  },
+  "graph": {
+    "id": "26aa25ab-f2ad-484d-bf96-00c5398f6d95",
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "contents_type": "Graph",
+    "contents": {
+      "nodes": [
+        {
+          "id": "2bddcb9a-0a02-4238-a6a0-4d60533c6a9f",
+          "name": "Thread",
+          "class_name": "nos.Thread",
+          "pins": [
+            {
+              "id": "85029388-c4f8-43eb-a122-245cd7078d23",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "live": true
+            },
+            {
+              "id": "d5188ab7-19e8-40ba-b883-a9cb014a2c59",
+              "name": "Importance",
+              "type_name": "ulong",
+              "show_as": "PROPERTY",
+              "can_show_as": "PROPERTY_ONLY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 86,
+            "y": -94
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          },
+          "always_execute": true
+        },
+        {
+          "id": "c8dc83f4-85d6-4a0a-bfd1-564c87fc0218",
+          "name": "TestScheduler",
+          "class_name": "nos.test.TestScheduler",
+          "pins": [
+            {
+              "id": "98de26bb-29da-481d-9ed3-5015c866f5cc",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "75e1801f-b0e8-4ab6-a237-1e96c165bab1",
+              "name": "Sink",
+              "type_name": "uint",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "80e16ef8-30a4-44b7-b9d6-330a50fccde0",
+              "name": "FreeRun",
+              "type_name": "bool",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": false,
+              "def": false,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "7b525ba0-59ac-461c-9da2-2b17e4fe45ed",
+              "name": "DeltaTime",
+              "type_name": "nos.fb.vec2u",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 1,
+                "y": 60
+              },
+              "def": {
+                "x": 1,
+                "y": 60
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 324,
+            "y": 7
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "d862ae3b-ffb2-412a-b42f-63bfdc14123e",
+          "name": "Assert",
+          "class_name": "nos.test.Assert",
+          "pins": [
+            {
+              "id": "e3529a8a-6678-4891-8793-daffcc57c2df",
+              "name": "Behaviour",
+              "type_name": "nos.test.AssertionBehaviour",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "EXIT_WITH_STATUS_CODE",
+              "def": "EXIT_WITH_STATUS_CODE",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "4a1f4387-0569-4866-bec4-b71c605c3aa0",
+              "name": "NumFramesToWait",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "b5377dd6-bcc1-4541-9b39-9db135867dfc",
+              "name": "FrameCount",
+              "type_name": "uint",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "751e927f-f619-4491-baf9-13b8a4af13ea",
+              "name": "Condition",
+              "type_name": "bool",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "c84bbb60-d870-4604-8b90-28a9288f276b",
+              "name": "NumFramesToAssertOver",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "min": 1
+            }
+          ],
+          "pos": {
+            "x": 93,
+            "y": 11
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "8a1eaf8d-97f3-4099-80dd-6f35da46ce78",
+          "name": "IsEqual",
+          "class_name": "nos.reflect.IsEqual",
+          "pins": [
+            {
+              "id": "fea9c79b-683a-4e09-b41c-c888f8cdfc31",
+              "name": "A",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "413c795c-9c84-41aa-a57b-150dfa6b438a",
+              "name": "B",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "6dcf653b-e2c2-49ff-805d-3cbf8b5fc4de",
+              "name": "IsEqual",
+              "type_name": "bool",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -105,
+            "y": 4
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "id": "6a1b74a2-27ae-42f8-aff6-a4d13fcd3d66",
+          "name": "EulerToQuaternion",
+          "class_name": "nos.math.EulerToQuaternion",
+          "pins": [
+            {
+              "id": "4d76c4c1-36dc-40eb-ac0a-b9b48b43ac5e",
+              "name": "Euler",
+              "type_name": "nos.fb.vec3d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              }
+            },
+            {
+              "id": "1302e6c8-7aca-4db8-bbd8-b670dec989de",
+              "name": "Order",
+              "type_name": "nos.math.EulerOrder",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": "ZYX",
+              "def": "ZYX"
+            },
+            {
+              "id": "935e3f58-fcad-4b84-9912-46048490898f",
+              "name": "Quaternion",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -266,
+            "y": 14
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "from": "85029388-c4f8-43eb-a122-245cd7078d23",
+          "to": "98de26bb-29da-481d-9ed3-5015c866f5cc",
+          "id": "4df2f3f2-6bee-437c-8b8d-8f89ceb94c11"
+        },
+        {
+          "from": "b5377dd6-bcc1-4541-9b39-9db135867dfc",
+          "to": "75e1801f-b0e8-4ab6-a237-1e96c165bab1",
+          "id": "e9c7132d-1198-4b32-b551-94e2ecb6e5a0"
+        },
+        {
+          "from": "6dcf653b-e2c2-49ff-805d-3cbf8b5fc4de",
+          "to": "751e927f-f619-4491-baf9-13b8a4af13ea",
+          "id": "8a7132d3-7990-4734-9710-a1672193fa7d"
+        },
+        {
+          "from": "935e3f58-fcad-4b84-9912-46048490898f",
+          "to": "fea9c79b-683a-4e09-b41c-c888f8cdfc31",
+          "id": "674d49e0-e650-4184-88fa-f91d35147324"
+        }
+      ]
+    },
+    "plugin_version": {
+      "major": 0,
+      "minor": 0,
+      "patch": 0
+    }
+  }
+}

--- a/Plugins/nosMath/Tests/QuaternionMultiply_Identity_Parity.nosa
+++ b/Plugins/nosMath/Tests/QuaternionMultiply_Identity_Parity.nosa
@@ -1,0 +1,431 @@
+{
+  "info": {
+    "version": "1.4.0.b0",
+    "loaded_modules": [
+      {
+        "name": "nos.test",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nos.reflect",
+        "version": "3.0.0"
+      },
+      {
+        "name": "nos.math",
+        "version": "2.1.0"
+      }
+    ]
+  },
+  "graph": {
+    "id": "ce9f67d1-5a3c-45a8-83a7-84a2295de195",
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "contents_type": "Graph",
+    "contents": {
+      "nodes": [
+        {
+          "id": "49a153f1-8149-4a7b-9215-ae4b683081b3",
+          "name": "Thread",
+          "class_name": "nos.Thread",
+          "pins": [
+            {
+              "id": "02713884-f5a4-4066-af8a-563336ef26f2",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "live": true
+            },
+            {
+              "id": "351487fd-de66-48d5-bb70-a10308a21267",
+              "name": "Importance",
+              "type_name": "ulong",
+              "show_as": "PROPERTY",
+              "can_show_as": "PROPERTY_ONLY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 86,
+            "y": -94
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          },
+          "always_execute": true
+        },
+        {
+          "id": "09b04503-dca9-4b42-8eeb-6a60e686ffb0",
+          "name": "TestScheduler",
+          "class_name": "nos.test.TestScheduler",
+          "pins": [
+            {
+              "id": "95453ccf-be6c-479a-a4ca-18830dcee60a",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "2f212c6f-5b23-41c3-ae3e-73e0a4eedf58",
+              "name": "Sink",
+              "type_name": "uint",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "d4523492-e398-43d0-86ff-6d440e278e54",
+              "name": "FreeRun",
+              "type_name": "bool",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": false,
+              "def": false,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "a8062e3e-019f-440d-9733-2eb92e2f0fce",
+              "name": "DeltaTime",
+              "type_name": "nos.fb.vec2u",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 1,
+                "y": 60
+              },
+              "def": {
+                "x": 1,
+                "y": 60
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 324,
+            "y": 7
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "51daad7f-1866-4fc6-9b58-495b0f814bd2",
+          "name": "Assert",
+          "class_name": "nos.test.Assert",
+          "pins": [
+            {
+              "id": "f2a60858-63f0-419b-a3c8-08f4258bac93",
+              "name": "Behaviour",
+              "type_name": "nos.test.AssertionBehaviour",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "EXIT_WITH_STATUS_CODE",
+              "def": "EXIT_WITH_STATUS_CODE",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "8f3148bd-9be2-42b2-9215-53305e3d6cbf",
+              "name": "NumFramesToWait",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "9b5714ac-f30b-48d0-891d-bc1d66694e96",
+              "name": "FrameCount",
+              "type_name": "uint",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "46de3683-bee2-4e34-844f-69e2790fb5cf",
+              "name": "Condition",
+              "type_name": "bool",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "64ac0c5e-5afd-4811-ba47-d4d3c71be60f",
+              "name": "NumFramesToAssertOver",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "min": 1
+            }
+          ],
+          "pos": {
+            "x": 93,
+            "y": 11
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "e4ba7f51-5785-4914-a767-0da76c4e19fb",
+          "name": "IsEqual",
+          "class_name": "nos.reflect.IsEqual",
+          "pins": [
+            {
+              "id": "478708e1-a93f-4354-b4e0-f49391e5bc4c",
+              "name": "A",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "cc7f7d72-52b6-43b0-95d1-b5669933cad2",
+              "name": "B",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "2710854a-7bec-4f94-8c81-04ebf24c5aa9",
+              "name": "IsEqual",
+              "type_name": "bool",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -105,
+            "y": 4
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "id": "4c29cb43-ba73-4d66-8406-0115c0c34b25",
+          "name": "QuaternionMultiply",
+          "class_name": "nos.math.QuaternionMultiply",
+          "pins": [
+            {
+              "id": "94fd4181-1288-4bf0-b960-b3a59a60c282",
+              "name": "A",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              }
+            },
+            {
+              "id": "1532711c-c840-4315-8091-b943105f1dd4",
+              "name": "B",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              }
+            },
+            {
+              "id": "49ee4453-15d5-4a36-9244-4fc952cfa14e",
+              "name": "Result",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -266,
+            "y": 14
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "from": "02713884-f5a4-4066-af8a-563336ef26f2",
+          "to": "95453ccf-be6c-479a-a4ca-18830dcee60a",
+          "id": "1e915187-b013-4edf-9b83-c3aeaa7b21ee"
+        },
+        {
+          "from": "9b5714ac-f30b-48d0-891d-bc1d66694e96",
+          "to": "2f212c6f-5b23-41c3-ae3e-73e0a4eedf58",
+          "id": "c321e769-d713-41ea-b38f-18498b9910ac"
+        },
+        {
+          "from": "2710854a-7bec-4f94-8c81-04ebf24c5aa9",
+          "to": "46de3683-bee2-4e34-844f-69e2790fb5cf",
+          "id": "f1bba839-181b-4189-84e2-0aa959776b54"
+        },
+        {
+          "from": "49ee4453-15d5-4a36-9244-4fc952cfa14e",
+          "to": "478708e1-a93f-4354-b4e0-f49391e5bc4c",
+          "id": "27f9612e-942c-45bf-8966-dfef96d735e1"
+        }
+      ]
+    },
+    "plugin_version": {
+      "major": 0,
+      "minor": 0,
+      "patch": 0
+    }
+  }
+}

--- a/Plugins/nosMath/Tests/QuaternionToEuler_Identity_Parity.nosa
+++ b/Plugins/nosMath/Tests/QuaternionToEuler_Identity_Parity.nosa
@@ -1,0 +1,417 @@
+{
+  "info": {
+    "version": "1.4.0.b0",
+    "loaded_modules": [
+      {
+        "name": "nos.test",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nos.reflect",
+        "version": "3.0.0"
+      },
+      {
+        "name": "nos.math",
+        "version": "2.1.0"
+      }
+    ]
+  },
+  "graph": {
+    "id": "67d835c9-a5c0-4b23-af56-30b8bb04a9cd",
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "contents_type": "Graph",
+    "contents": {
+      "nodes": [
+        {
+          "id": "21c0c44a-1327-47a2-a6f9-dab832965538",
+          "name": "Thread",
+          "class_name": "nos.Thread",
+          "pins": [
+            {
+              "id": "1ef2979f-c079-4de0-a084-c22e950bead1",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "live": true
+            },
+            {
+              "id": "91c54ed8-0afa-48d4-bded-f9e167f7b4ed",
+              "name": "Importance",
+              "type_name": "ulong",
+              "show_as": "PROPERTY",
+              "can_show_as": "PROPERTY_ONLY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 86,
+            "y": -94
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          },
+          "always_execute": true
+        },
+        {
+          "id": "983dba73-10a2-4637-bc83-706f249ea14e",
+          "name": "TestScheduler",
+          "class_name": "nos.test.TestScheduler",
+          "pins": [
+            {
+              "id": "603a07c7-245f-42a5-922a-6cb08207f059",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "7e933b31-afad-485c-ba13-4f3a58378503",
+              "name": "Sink",
+              "type_name": "uint",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "096c2bd4-7bdf-4de7-938c-c39fe4ffce4c",
+              "name": "FreeRun",
+              "type_name": "bool",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": false,
+              "def": false,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "0a39415e-268e-490d-a83d-572f2db52261",
+              "name": "DeltaTime",
+              "type_name": "nos.fb.vec2u",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 1,
+                "y": 60
+              },
+              "def": {
+                "x": 1,
+                "y": 60
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 324,
+            "y": 7
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "3b56d900-1a1f-43e1-9558-1259c643a816",
+          "name": "Assert",
+          "class_name": "nos.test.Assert",
+          "pins": [
+            {
+              "id": "877ca178-d08b-4756-b87e-e669e83c11e4",
+              "name": "Behaviour",
+              "type_name": "nos.test.AssertionBehaviour",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "EXIT_WITH_STATUS_CODE",
+              "def": "EXIT_WITH_STATUS_CODE",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "4d85aee0-dc55-4d4e-8501-29fd0b1f5bff",
+              "name": "NumFramesToWait",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "2d4a0cb0-01a4-49e3-8c99-b69153b0cadb",
+              "name": "FrameCount",
+              "type_name": "uint",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "01815178-824c-4c17-b9eb-920d93c1815d",
+              "name": "Condition",
+              "type_name": "bool",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "20d4fd63-c995-429a-830a-c1d7e3b39826",
+              "name": "NumFramesToAssertOver",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "min": 1
+            }
+          ],
+          "pos": {
+            "x": 93,
+            "y": 11
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "98e0ee95-32e8-4c53-aca0-aba86e23d653",
+          "name": "IsEqual",
+          "class_name": "nos.reflect.IsEqual",
+          "pins": [
+            {
+              "id": "427a26b5-2aa5-4feb-96cb-d0eca0cf80ad",
+              "name": "A",
+              "type_name": "nos.fb.vec3d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "1e27dbe6-9140-47b0-b690-3bda2485b759",
+              "name": "B",
+              "type_name": "nos.fb.vec3d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "ef445555-68ac-45f4-a421-b29f2ac66678",
+              "name": "IsEqual",
+              "type_name": "bool",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -105,
+            "y": 4
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "id": "67512810-02a1-4f5a-8477-02bf13268ae2",
+          "name": "QuaternionToEuler",
+          "class_name": "nos.math.QuaternionToEuler",
+          "pins": [
+            {
+              "id": "4433df43-2449-4c55-a7c4-187da3d9904c",
+              "name": "Quaternion",
+              "type_name": "nos.fb.vec4d",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              },
+              "def": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "w": 1.0
+              }
+            },
+            {
+              "id": "89482247-ac8c-4b8a-934e-55ff182c99e1",
+              "name": "Order",
+              "type_name": "nos.math.EulerOrder",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": "ZYX",
+              "def": "ZYX"
+            },
+            {
+              "id": "8b57aa05-20de-4ff7-af1c-c71f199d80c5",
+              "name": "Euler",
+              "type_name": "nos.fb.vec3d",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -266,
+            "y": 14
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "from": "1ef2979f-c079-4de0-a084-c22e950bead1",
+          "to": "603a07c7-245f-42a5-922a-6cb08207f059",
+          "id": "cfc61676-ed6e-4843-acd1-90159ebf0137"
+        },
+        {
+          "from": "2d4a0cb0-01a4-49e3-8c99-b69153b0cadb",
+          "to": "7e933b31-afad-485c-ba13-4f3a58378503",
+          "id": "c826d7d8-d497-490b-b01b-7a8667bc894f"
+        },
+        {
+          "from": "ef445555-68ac-45f4-a421-b29f2ac66678",
+          "to": "01815178-824c-4c17-b9eb-920d93c1815d",
+          "id": "d1b02395-2af7-4d9b-b64e-3ea5a4270c18"
+        },
+        {
+          "from": "8b57aa05-20de-4ff7-af1c-c71f199d80c5",
+          "to": "427a26b5-2aa5-4feb-96cb-d0eca0cf80ad",
+          "id": "ca6f5733-6882-40c3-95ac-d8cf3bc0bf25"
+        }
+      ]
+    },
+    "plugin_version": {
+      "major": 0,
+      "minor": 0,
+      "patch": 0
+    }
+  }
+}

--- a/Plugins/nosMath/Types/Math.fbs
+++ b/Plugins/nosMath/Types/Math.fbs
@@ -1,0 +1,10 @@
+namespace nos.math;
+
+enum EulerOrder : ubyte {
+	ZYX = 0,
+	XYZ = 1,
+	YXZ = 2,
+	YZX = 3,
+	ZXY = 4,
+	XZY = 5,
+}

--- a/Plugins/nosResource/Nodes/MultiBoundedQueue.nosnode
+++ b/Plugins/nosResource/Nodes/MultiBoundedQueue.nosnode
@@ -1,0 +1,56 @@
+{
+	"nodes": [
+		{
+			"class_name": "MultiBoundedQueue",
+			"menu_info": {
+				"category": "Utilities",
+				"display_name": "Multi Bounded Queue",
+				"name_aliases": [ "data structure", "algorithm", "circular", "multi", "fifo" ]
+			},
+			"node": {
+				"class_name": "MultiBoundedQueue",
+				"display_name": "Multi Bounded Queue",
+				"contents_type": "Job",
+				"description": "Bounded FIFO queue with one or more independent input/output channel pairs sharing a single bound. Right-click the node to add a channel, right-click an Input_X or Output_X pin to remove its channel.",
+				"pins": [
+					{
+						"name": "Thread",
+						"type_name": "nos.exe",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "Size",
+						"type_name": "uint",
+						"data": 2,
+						"max": 120,
+						"min": 1,
+						"show_as": "PROPERTY",
+						"can_show_as": "PROPERTY_ONLY"
+					},
+					{
+						"name": "Alignment",
+						"description": "Used for creating memory-aligned buffers in memory",
+						"type_name": "uint",
+						"def": 0,
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Input_A",
+						"type_name": "nos.Generic",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "Output_A",
+						"type_name": "nos.Generic",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"live": true
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosResource/Nodes/MultiRingBuffer.nosnode
+++ b/Plugins/nosResource/Nodes/MultiRingBuffer.nosnode
@@ -1,0 +1,74 @@
+{
+	"nodes": [
+		{
+			"class_name": "MultiRingBuffer",
+			"menu_info": {
+				"category": "Utilities",
+				"display_name": "Multi Ring Buffer",
+				"name_aliases": [ "data structure", "algorithm", "circular", "multi" ]
+			},
+			"node": {
+				"class_name": "MultiRingBuffer",
+				"display_name": "Multi Ring Buffer",
+				"contents_type": "Job",
+				"description": "Ring buffer with one or more independent input/output channel pairs sharing a single ring size. Right-click the node to add a channel, right-click an Input_X or Output_X pin to remove its channel.",
+				"pins": [
+					{
+						"name": "Thread",
+						"type_name": "nos.exe",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "Size",
+						"type_name": "uint",
+						"data": 2,
+						"max": 120,
+						"min": 1,
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Spare",
+						"type_name": "uint",
+						"data": 0,
+						"max": 119,
+						"min": 0,
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Alignment",
+						"description": "Used for creating memory-aligned buffers in memory",
+						"type_name": "uint",
+						"def": 0,
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Input_A",
+						"type_name": "nos.Generic",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "Output_A",
+						"type_name": "nos.Generic",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"live": true
+					},
+					{
+						"name": "RepeatWhenFilling",
+						"display_name": "Repeat When Filling",
+						"type_name": "bool",
+						"description": "Serves the last value while the buffer is being filled instead of waiting & resets the ring on restart",
+						"def": true,
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosResource/Source/MultiBoundedQueue.cpp
+++ b/Plugins/nosResource/Source/MultiBoundedQueue.cpp
@@ -1,0 +1,605 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#pragma once
+
+#include <set>
+
+#include <Nodos/Plugin.hpp>
+
+// External
+#include <glm/glm.hpp>
+#include <nosSysVulkan/Helpers.hpp>
+
+#include "MultiRing.h"
+#include "Ring.h"
+
+namespace nos::resource
+{
+
+struct MultiBoundedQueueNodeContext : NodeContext
+{
+	static constexpr std::string_view CHANNEL_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+	enum MenuCommandType : uint8_t
+	{
+		ADD_CHANNEL = 0,
+		REMOVE_CHANNEL = 1,
+	};
+
+	struct MenuCommand
+	{
+		MenuCommandType Type;
+		uint8_t Letter;
+		MenuCommand(uint32_t cmd)
+		{
+			Type = static_cast<MenuCommandType>(cmd & 0xFF);
+			Letter = static_cast<uint8_t>((cmd >> 8) & 0xFF);
+		}
+		MenuCommand(MenuCommandType type, uint8_t letter) : Type(type), Letter(letter) {}
+		operator uint32_t() const { return (Letter << 8) | Type; }
+	};
+
+	struct Channel
+	{
+		char Letter;
+		nos::Name InputName;
+		nos::Name OutputName;
+		uuid InputId{};
+		uuid OutputId{};
+		nos::TypeInfo TypeInfo;
+		MultiRing::Channel* RingChannel = nullptr;
+		std::atomic_bool IsOutLive = false;
+		bool NeedsRecreation = false;
+
+		Channel(char letter)
+			: Letter(letter),
+			  InputName((std::string("Input_") + letter).c_str()),
+			  OutputName((std::string("Output_") + letter).c_str()),
+			  TypeInfo(NSN_Generic)
+		{
+		}
+	};
+
+	std::map<char, std::unique_ptr<Channel>> Channels;
+	std::unordered_map<uuid, char> PinIdToLetter;
+	MultiRing Ring;
+	// Channels popped since the last SendScheduleRequest. One producer run
+	// pushes one slot per live channel, so we must only schedule again once
+	// every live channel has been popped — otherwise schedule requests pile
+	// up by a factor of N (channels) per consumer tick.
+	std::set<char> PoppedSinceLastSchedule;
+
+	std::optional<uint32_t> RequestedRingSize = std::nullopt;
+
+	std::string GetName() const { return "MultiBoundedQueue"; }
+
+	static std::optional<char> ParseLetter(std::string_view pinName)
+	{
+		auto pos = pinName.find_last_of('_');
+		if (pos == std::string::npos || pos + 2 != pinName.size())
+			return std::nullopt;
+		char c = pinName[pos + 1];
+		if (c < 'A' || c > 'Z')
+			return std::nullopt;
+		return c;
+	}
+
+	static bool IsInputPin(std::string_view pinName) { return pinName.starts_with("Input_"); }
+	static bool IsOutputPin(std::string_view pinName) { return pinName.starts_with("Output_"); }
+
+	using NodeContext::NodeContext;
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		std::vector<uuid> pinsToUnorphan;
+		for (auto* pin : *node->pins())
+		{
+			auto pinNameSv = pin->name()->string_view();
+			if (!IsInputPin(pinNameSv) && !IsOutputPin(pinNameSv))
+				continue;
+			auto letter = ParseLetter(pinNameSv);
+			if (!letter)
+				continue;
+
+			auto& channel = Channels[*letter];
+			if (!channel)
+				channel = std::make_unique<Channel>(*letter);
+
+			if (IsInputPin(pinNameSv))
+				channel->InputId = uuid(*pin->id());
+			else
+			{
+				channel->OutputId = uuid(*pin->id());
+				channel->IsOutLive = pin->live();
+			}
+			PinIdToLetter[uuid(*pin->id())] = *letter;
+
+			nos::Name typeName(pin->type_name()->c_str());
+			if (typeName != NSN_Generic && channel->TypeInfo->TypeName == NSN_Generic)
+				channel->TypeInfo = nos::TypeInfo(typeName);
+
+			if (auto orphanState = pin->orphan_state())
+				if (orphanState->type() == fb::PinOrphanStateType::ORPHAN)
+					pinsToUnorphan.push_back(uuid(*pin->id()));
+		}
+
+		for (auto& [_, ch] : Channels)
+			InitChannel(*ch);
+
+		for (auto const& pinId : pinsToUnorphan)
+			SetPinOrphanState(pinId, fb::PinOrphanStateType::ACTIVE);
+
+		AddPinValueWatcher(NSN_Size, [this](nos::Buffer const& newSize, std::optional<nos::Buffer> oldVal) {
+			uint32_t size = *newSize.As<uint32_t>();
+			if (oldVal && oldVal == newSize)
+				return;
+			RequestRingResize(size);
+		});
+		AddPinObjectWatcher(NSN_Alignment, [this](ObjectRef newAlignment, std::optional<ObjectRef>) {
+			bool any = false;
+			for (auto& [_, ch] : Channels)
+			{
+				if (!ch->RingChannel)
+					continue;
+				if (ch->RingChannel->ResInterface->CheckNewResource(NSN_Alignment, newAlignment))
+				{
+					nosEngine.SendPathRestart(ch->InputId);
+					ch->NeedsRecreation = true;
+					any = true;
+				}
+			}
+			if (any)
+			{
+				Ring.Stop();
+				PoppedSinceLastSchedule.clear();
+			}
+		});
+		return NOS_RESULT_SUCCESS;
+	}
+
+	~MultiBoundedQueueNodeContext() override { Ring.Stop(); }
+
+	void InitChannel(Channel& ch)
+	{
+		std::shared_ptr<ResourceInterface> resource;
+		if (ch.TypeInfo->TypeName == NOS_NAME(sys::vulkan::Buffer::GetFullyQualifiedName()))
+			resource = std::make_shared<GPUBufferResource>();
+		else if (ch.TypeInfo->TypeName == NOS_NAME(sys::vulkan::Texture::GetFullyQualifiedName()))
+			resource = std::make_shared<GPUTextureResource>();
+		else
+			resource = std::make_shared<PODResource>();
+
+		ch.RingChannel = &Ring.AddChannel(ch.Letter, std::move(resource), &ch);
+
+		Channel* chPtr = &ch;
+		AddPinObjectWatcher(ch.InputName, [this, chPtr](ObjectRef newObj, std::optional<ObjectRef>) {
+			if (!chPtr->RingChannel)
+				return;
+			if (chPtr->RingChannel->ResInterface->CheckNewResource(NSN_Input, newObj))
+			{
+				nosEngine.SendPathRestart(chPtr->InputId);
+				Ring.Stop();
+				PoppedSinceLastSchedule.clear();
+				chPtr->NeedsRecreation = true;
+			}
+		});
+	}
+
+	Channel* GetChannelByPinId(uuid const& id)
+	{
+		auto it = PinIdToLetter.find(id);
+		if (it == PinIdToLetter.end())
+			return nullptr;
+		auto chIt = Channels.find(it->second);
+		return chIt != Channels.end() ? chIt->second.get() : nullptr;
+	}
+
+	void RequestRingResize(uint32_t size)
+	{
+		if (size == 0)
+		{
+			nosEngine.LogW((GetName() + " size cannot be 0").c_str());
+			return;
+		}
+		if (Ring.Size == size && (!RequestedRingSize.has_value() || *RequestedRingSize == size))
+			return;
+		for (auto& [_, ch] : Channels)
+		{
+			if (!ch->RingChannel)
+				continue;
+			nosPathCommand ringSizeChange{.Event = NOS_RING_SIZE_CHANGE, .RingSize = size};
+			nosEngine.SendPathCommand(ch->InputId, ringSizeChange);
+		}
+		Ring.Stop();
+		PoppedSinceLastSchedule.clear();
+		SendPathRestart();
+		RequestedRingSize = size;
+	}
+
+	void SendPathRestart()
+	{
+		for (auto& [_, ch] : Channels)
+			nosEngine.SendPathRestart(ch->InputId);
+	}
+
+	nosResult OnResolvePinDataTypes(nosResolvePinDataTypesParams* params) override
+	{
+		auto pinNameStr = nos::Name(params->InstigatorPinName).AsString();
+		auto letter = ParseLetter(pinNameStr);
+		if (!letter)
+			return NOS_RESULT_FAILED;
+		auto chIt = Channels.find(*letter);
+		if (chIt == Channels.end())
+			return NOS_RESULT_FAILED;
+		auto& ch = *chIt->second;
+		if (ch.TypeInfo->TypeName != NSN_Generic)
+			return NOS_RESULT_FAILED;
+		ch.TypeInfo = nos::TypeInfo(params->IncomingTypeName);
+		if (ch.RingChannel)
+		{
+			Ring.Stop();
+			PoppedSinceLastSchedule.clear();
+			Ring.RemoveChannel(*letter);
+			ch.RingChannel = nullptr;
+		}
+		for (size_t i = 0; i < params->PinCount; i++)
+		{
+			auto& pinInfo = params->Pins[i];
+			if (pinInfo.Id == ch.InputId || pinInfo.Id == ch.OutputId)
+				pinInfo.OutResolvedTypeName = ch.TypeInfo->TypeName;
+		}
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinUpdated(const nosPinUpdate*) override
+	{
+		for (auto& [_, ch] : Channels)
+			if (!ch->RingChannel)
+				InitChannel(*ch);
+	}
+
+	void OnNodeUpdated(nosNodeUpdate const* update) override
+	{
+		if (update->Type == NOS_NODE_UPDATE_PIN_DELETED)
+		{
+			auto it = PinIdToLetter.find(update->PinDeleted);
+			if (it == PinIdToLetter.end())
+				return;
+			char letter = it->second;
+			PinIdToLetter.erase(it);
+			auto chIt = Channels.find(letter);
+			if (chIt == Channels.end())
+				return;
+			auto& ch = *chIt->second;
+			bool inputAlive = PinIdToLetter.contains(ch.InputId);
+			bool outputAlive = PinIdToLetter.contains(ch.OutputId);
+			if (!inputAlive && !outputAlive)
+			{
+				if (ch.RingChannel)
+				{
+					Ring.RemoveChannel(letter);
+					ch.RingChannel = nullptr;
+				}
+				Channels.erase(chIt);
+			}
+		}
+		else if (update->Type == NOS_NODE_UPDATE_PIN_CREATED)
+		{
+			auto* pin = update->PinCreated;
+			auto sv = pin->name()->string_view();
+			if (!IsInputPin(sv) && !IsOutputPin(sv))
+				return;
+			auto letter = ParseLetter(sv);
+			if (!letter)
+				return;
+			auto& chPtr = Channels[*letter];
+			if (!chPtr)
+				chPtr = std::make_unique<Channel>(*letter);
+			if (IsInputPin(sv))
+				chPtr->InputId = uuid(*pin->id());
+			else
+			{
+				chPtr->OutputId = uuid(*pin->id());
+				chPtr->IsOutLive = pin->live();
+			}
+			PinIdToLetter[uuid(*pin->id())] = *letter;
+			if (!chPtr->RingChannel)
+				InitChannel(*chPtr);
+		}
+	}
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		if (Channels.empty() || Ring.Exit)
+			return NOS_RESULT_FAILED;
+
+		uint32_t requestedSize = *params.GetPinValue<uint32_t>(NSN_Size);
+
+		struct Gathered
+		{
+			Channel* NodeCh;
+			MultiRing::Channel* RingCh;
+			ObjectRef Input;
+		};
+		std::vector<Gathered> gathered;
+		gathered.reserve(Channels.size());
+		std::vector<MultiRing::Channel*> wantedRings;
+		wantedRings.reserve(Channels.size());
+
+		uint32_t maxRequired = requestedSize;
+		for (auto& [_, ch] : Channels)
+		{
+			if (!ch->RingChannel || ch->RingChannel->Resources.empty() || !ch->TypeInfo)
+				continue;
+			auto it = params.find(ch->InputName);
+			if (it == params.end())
+				continue;
+			ObjectRef input = ch->RingChannel->ResInterface->ValidateAndGetPinObject(it->second, false);
+			if (!input.IsValid())
+				continue;
+			uint32_t required = ch->RingChannel->ResInterface->GetRequiredRingSize(input, requestedSize);
+			if (required > maxRequired)
+				maxRequired = required;
+			gathered.push_back({ch.get(), ch->RingChannel, input});
+			wantedRings.push_back(ch->RingChannel);
+		}
+		if (gathered.empty())
+		{
+			SendScheduleRequest(0);
+			return NOS_RESULT_FAILED;
+		}
+
+		if (Ring.Size != maxRequired)
+		{
+			RequestRingResize(maxRequired);
+			return NOS_RESULT_FAILED;
+		}
+
+		std::vector<MultiRing::SlotPair> slots;
+		if (!Ring.BeginPushSubset(100, wantedRings, slots))
+			return Ring.Exit ? NOS_RESULT_FAILED : NOS_RESULT_PENDING;
+
+		for (size_t i = 0; i < gathered.size(); ++i)
+		{
+			auto& g = gathered[i];
+			auto* slot = slots[i].second;
+			g.RingCh->ResInterface->Push(slot, g.Input, params,
+										 NOS_NAME_STATIC("MultiBoundedQueue"), false);
+			if (!g.NodeCh->IsOutLive)
+			{
+				ChangePinLiveness(g.NodeCh->OutputName, true);
+				g.NodeCh->IsOutLive = true;
+			}
+		}
+
+		Ring.EndPushAll(slots);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	nosResult CopyFrom(nosCopyFromInfo* cpy) override
+	{
+		auto* ch = GetChannelByPinId(cpy->ID);
+		if (!ch || !ch->RingChannel || Ring.Exit)
+			return NOS_RESULT_FAILED;
+		if (!ch->IsOutLive)
+			return NOS_RESULT_SUCCESS;
+
+		ResourceInterface::ResourceBase* slot;
+		{
+			ScopedProfilerEvent _({.Name = "Wait For Filled Slot"});
+			slot = Ring.BeginPop(*ch->RingChannel, 100);
+		}
+		if (!slot)
+			return Ring.Exit ? NOS_RESULT_FAILED : NOS_RESULT_PENDING;
+
+		// Propagate the slot resource's descriptor onto the output pin before
+		// Copy reads cpy->PinObjectHandle as the destination — otherwise the GPU copy
+		// targets the stale (default-sized) output descriptor.
+		ObjectRef outPinObj{};
+		if (ch->RingChannel->ResInterface->BeginCopyFrom(slot, *cpy->PinObjectHandle, outPinObj))
+			SetPinObject(ch->OutputName, outPinObj);
+
+		ch->RingChannel->ResInterface->Copy(slot, cpy, NodeId);
+
+		cpy->ShouldSetSourceFrameNumber = true;
+		cpy->FrameNumber = slot->FrameNumber;
+
+		Ring.EndPop(*ch->RingChannel, slot);
+
+		PoppedSinceLastSchedule.insert(ch->Letter);
+		size_t liveCount = 0;
+		for (auto& [_, c] : Channels)
+			if (c->IsOutLive)
+				++liveCount;
+		if (PoppedSinceLastSchedule.size() >= liveCount)
+		{
+			SendScheduleRequest(1);
+			PoppedSinceLastSchedule.clear();
+		}
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnEndFrame(uuid const& pinId, nosEndFrameCause cause) override
+	{
+		if (cause != NOS_END_FRAME_FAILED)
+			return;
+		auto* ch = GetChannelByPinId(pinId);
+		if (!ch)
+			return;
+		if (pinId == ch->OutputId)
+			return;
+		if (!ch->IsOutLive)
+			return;
+		ChangePinLiveness(ch->OutputName, false);
+		ch->IsOutLive = false;
+	}
+
+	void SendScheduleRequest(uint32_t count, bool reset = false) const
+	{
+		nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = count, .Reset = reset};
+		nosEngine.ScheduleNode(&schedule);
+	}
+
+	void OnPathCommand(const nosPathCommand* command) override
+	{
+		switch (command->Event)
+		{
+		case NOS_RING_SIZE_CHANGE:
+			if (command->RingSize == 0)
+				return;
+			RequestedRingSize = command->RingSize;
+			nosEngine.SetPinValue(*GetPinId(NSN_Size), nos::Buffer::From(command->RingSize));
+			break;
+		default: return;
+		}
+	}
+
+	void OnPathStop() override
+	{
+		Ring.Stop();
+		PoppedSinceLastSchedule.clear();
+	}
+
+	void OnPathStart() override
+	{
+		if (Channels.empty())
+			return;
+
+		PoppedSinceLastSchedule.clear();
+
+		Ring.ResetAll(false);
+
+		if (RequestedRingSize)
+		{
+			Ring.ResizeAll(*RequestedRingSize);
+			for (auto& [_, ch] : Channels)
+				ch->NeedsRecreation = false;
+			RequestedRingSize = std::nullopt;
+		}
+		for (auto& [_, ch] : Channels)
+		{
+			if (ch->NeedsRecreation && ch->RingChannel)
+			{
+				Ring.RecreateChannelResources(*ch->RingChannel);
+				ch->NeedsRecreation = false;
+			}
+		}
+
+		size_t totalSchedule = 0;
+		for (auto& [_, ch] : Channels)
+		{
+			if (!ch->RingChannel)
+				continue;
+			if (ch->RingChannel->Resources.empty())
+			{
+				totalSchedule = std::max<size_t>(totalSchedule, 1);
+				continue;
+			}
+			auto emptySlotCount = Ring.WritePoolSize(*ch->RingChannel);
+			totalSchedule = std::max(totalSchedule, emptySlotCount);
+			ch->RingChannel->ResInterface->OnPathStart();
+		}
+		Ring.Start();
+		if (totalSchedule > 0)
+		{
+			nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = (uint32_t)totalSchedule};
+			nosEngine.ScheduleNode(&schedule);
+		}
+	}
+
+	void OnNodeMenuRequested(nosContextMenuRequestPtr request) override
+	{
+		flatbuffers::FlatBufferBuilder fbb;
+		std::vector items = {
+			nos::CreateContextMenuItemDirect(fbb, "Add Channel", MenuCommand(ADD_CHANNEL, 0))};
+		HandleEvent(CreateAppEvent(fbb, app::CreateAppContextMenuUpdateDirect(
+											fbb, request->item_id(), request->pos(), request->instigator(), &items)));
+	}
+
+	void OnPinMenuRequested(nos::Name pinName, nosContextMenuRequestPtr request) override
+	{
+		auto sv = pinName.AsString();
+		if (!IsInputPin(sv) && !IsOutputPin(sv))
+			return;
+		auto letter = ParseLetter(sv);
+		if (!letter)
+			return;
+		if (Channels.size() <= 1)
+			return;
+		flatbuffers::FlatBufferBuilder fbb;
+		std::vector items = {nos::CreateContextMenuItemDirect(
+			fbb, "Remove Channel", MenuCommand(REMOVE_CHANNEL, static_cast<uint8_t>(*letter)))};
+		HandleEvent(CreateAppEvent(fbb, app::CreateAppContextMenuUpdateDirect(
+											fbb, request->item_id(), request->pos(), request->instigator(), &items)));
+	}
+
+	void OnMenuCommand(uuid const& itemID, uint32_t cmd) override
+	{
+		auto command = MenuCommand(cmd);
+		switch (command.Type)
+		{
+		case ADD_CHANNEL:
+		{
+			char newLetter = 0;
+			for (char c : CHANNEL_LETTERS)
+			{
+				if (!Channels.contains(c))
+				{
+					newLetter = c;
+					break;
+				}
+			}
+			if (newLetter == 0)
+			{
+				SetNodeStatusMessage("Maximum number of channels reached", fb::NodeStatusMessageType::WARNING);
+				return;
+			}
+
+			fb::TPin inPin;
+			inPin.id = uuid(nosEngine.GenerateID());
+			inPin.name = std::string("Input_") + newLetter;
+			inPin.type_name = "nos.Generic";
+			inPin.show_as = fb::ShowAs::INPUT_PIN;
+			inPin.can_show_as = fb::CanShowAs::INPUT_PIN_ONLY;
+
+			fb::TPin outPin;
+			outPin.id = uuid(nosEngine.GenerateID());
+			outPin.name = std::string("Output_") + newLetter;
+			outPin.type_name = "nos.Generic";
+			outPin.show_as = fb::ShowAs::OUTPUT_PIN;
+			outPin.can_show_as = fb::CanShowAs::OUTPUT_PIN_ONLY;
+			outPin.live = true;
+
+			nos::TPartialNodeUpdate update;
+			update.node_id = NodeId;
+			update.pins_to_add.emplace_back(std::make_unique<fb::TPin>(std::move(inPin)));
+			update.pins_to_add.emplace_back(std::make_unique<fb::TPin>(std::move(outPin)));
+			flatbuffers::FlatBufferBuilder fbb;
+			HandleEvent(CreateAppEvent(fbb, nos::CreatePartialNodeUpdate(fbb, &update)));
+			break;
+		}
+		case REMOVE_CHANNEL:
+		{
+			char letter = static_cast<char>(command.Letter);
+			auto it = Channels.find(letter);
+			if (it == Channels.end())
+				return;
+			auto& ch = *it->second;
+			nos::TPartialNodeUpdate update;
+			update.node_id = NodeId;
+			update.pins_to_delete = {ch.InputId, ch.OutputId};
+			flatbuffers::FlatBufferBuilder fbb;
+			HandleEvent(CreateAppEvent(fbb, nos::CreatePartialNodeUpdate(fbb, &update)));
+			break;
+		}
+		}
+	}
+};
+
+nosResult RegisterMultiBoundedQueue(nosNodeFunctions* functions)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("MultiBoundedQueue"), MultiBoundedQueueNodeContext, functions)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::resource

--- a/Plugins/nosResource/Source/MultiRing.h
+++ b/Plugins/nosResource/Source/MultiRing.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+ */
+
+#pragma once
+
+#include "Ring.h"
+
+namespace nos::resource
+{
+
+// Ring that holds N independent channels under a single mutex / CV pair.
+// Each channel still owns its own slot pools and Resources, but every push,
+// pop, resize and reset goes through the shared synchronization, so an
+// N-channel batch push is a single lock acquisition, not N.
+struct MultiRing
+{
+	struct Channel
+	{
+		std::shared_ptr<ResourceInterface> ResInterface;
+		std::vector<rc<ResourceInterface::ResourceBase>> Resources;
+		std::deque<ResourceInterface::ResourceBase*> WritePool;
+		std::deque<ResourceInterface::ResourceBase*> ReadPool;
+		void* UserData = nullptr;
+	};
+
+	std::map<char, std::unique_ptr<Channel>> Channels;
+	std::mutex Mutex;
+	std::condition_variable WriteCV;
+	std::condition_variable ReadCV;
+	std::atomic_bool Exit = true;
+	uint32_t Size = 0;
+
+	~MultiRing() { Stop(); }
+
+	void Stop()
+	{
+		{
+			std::unique_lock lock(Mutex);
+			Exit = true;
+		}
+		WriteCV.notify_all();
+		ReadCV.notify_all();
+	}
+
+	void Start()
+	{
+		std::unique_lock lock(Mutex);
+		Exit = false;
+	}
+
+	void AllocateChannelResourcesUnlocked(Channel& ch)
+	{
+		ch.WritePool.clear();
+		ch.ReadPool.clear();
+		ch.Resources.clear();
+		for (uint32_t i = 0; i < Size; ++i)
+		{
+			auto res = ch.ResInterface->CreateResource();
+			if (!res)
+			{
+				nosEngine.LogE("Failed to create resource for multi ring buffer.");
+				ch.Resources.clear();
+				ch.WritePool.clear();
+				ch.ReadPool.clear();
+				Exit = true;
+				return;
+			}
+			ch.Resources.push_back(res);
+			ch.WritePool.push_back(res.get());
+		}
+	}
+
+	Channel& AddChannel(char key, std::shared_ptr<ResourceInterface> resInterface, void* userData = nullptr)
+	{
+		std::unique_lock lock(Mutex);
+		auto& ch = Channels[key];
+		if (!ch)
+			ch = std::make_unique<Channel>();
+		ch->ResInterface = std::move(resInterface);
+		ch->UserData = userData;
+		if (Size == 0)
+			Size = 1;
+		AllocateChannelResourcesUnlocked(*ch);
+		return *ch;
+	}
+
+	void RemoveChannel(char key)
+	{
+		std::unique_lock lock(Mutex);
+		Channels.erase(key);
+	}
+
+	void RecreateChannelResources(Channel& ch)
+	{
+		std::unique_lock lock(Mutex);
+		AllocateChannelResourcesUnlocked(ch);
+	}
+
+	void ResizeAll(uint32_t newSize)
+	{
+		std::unique_lock lock(Mutex);
+		Size = newSize;
+		for (auto& [_, ch] : Channels)
+			AllocateChannelResourcesUnlocked(*ch);
+	}
+
+	bool AreAllChannelsValid()
+	{
+		std::unique_lock lock(Mutex);
+		if (Channels.empty())
+			return false;
+		for (auto& [_, ch] : Channels)
+			if (ch->Resources.empty())
+				return false;
+		return true;
+	}
+
+	// Move slots between pools for every channel. fill=false: read→write.
+	void ResetAll(bool fill)
+	{
+		std::unique_lock lock(Mutex);
+		for (auto& [_, ch] : Channels)
+		{
+			auto& from = fill ? ch->WritePool : ch->ReadPool;
+			auto& to = fill ? ch->ReadPool : ch->WritePool;
+			while (!from.empty())
+			{
+				auto* slot = from.front();
+				from.pop_front();
+				ch->ResInterface->Reset(slot);
+				to.push_back(slot);
+			}
+		}
+	}
+
+	// If this channel is full and its read pool is non-empty, hand one slot
+	// back to the write pool so the producer can start pushing again.
+	void MoveOneReadToWriteIfFull(Channel& ch)
+	{
+		std::unique_lock lock(Mutex);
+		if (ch.ReadPool.size() != ch.Resources.size() || ch.ReadPool.empty())
+			return;
+		auto* slot = ch.ReadPool.front();
+		ch.ReadPool.pop_front();
+		ch.WritePool.push_back(slot);
+	}
+
+	bool IsFull(Channel const& ch)
+	{
+		std::unique_lock lock(Mutex);
+		return ch.ReadPool.size() == ch.Resources.size();
+	}
+
+	bool IsEmpty(Channel const& ch)
+	{
+		std::unique_lock lock(Mutex);
+		return ch.ReadPool.empty();
+	}
+
+	size_t WritePoolSize(Channel const& ch)
+	{
+		std::unique_lock lock(Mutex);
+		return ch.WritePool.size();
+	}
+
+	size_t ReadPoolSize(Channel const& ch)
+	{
+		std::unique_lock lock(Mutex);
+		return ch.ReadPool.size();
+	}
+
+	using SlotPair = std::pair<Channel*, ResourceInterface::ResourceBase*>;
+
+	// Atomically pop one slot from each requested channel's WritePool.
+	// Waits until every requested channel has at least one slot, or
+	// timeout/exit. The caller-supplied list typically excludes channels
+	// that don't have valid input data this frame.
+	bool BeginPushSubset(uint64_t timeoutMs,
+						 std::vector<Channel*> const& wanted,
+						 std::vector<SlotPair>& outSlots)
+	{
+		std::unique_lock lock(Mutex);
+		auto pred = [&] {
+			if (Exit)
+				return true;
+			if (wanted.empty())
+				return false;
+			for (auto* ch : wanted)
+				if (ch->WritePool.empty())
+					return false;
+			return true;
+		};
+		if (!WriteCV.wait_for(lock, std::chrono::milliseconds(timeoutMs), pred))
+			return false;
+		if (Exit)
+			return false;
+		outSlots.clear();
+		outSlots.reserve(wanted.size());
+		for (auto* ch : wanted)
+		{
+			auto* slot = ch->WritePool.front();
+			ch->WritePool.pop_front();
+			outSlots.emplace_back(ch, slot);
+		}
+		return true;
+	}
+
+	void EndPushAll(std::vector<SlotPair> const& slots)
+	{
+		{
+			std::unique_lock lock(Mutex);
+			for (auto& [ch, slot] : slots)
+				ch->ReadPool.push_back(slot);
+		}
+		ReadCV.notify_all();
+	}
+
+	void CancelPushAll(std::vector<SlotPair> const& slots)
+	{
+		{
+			std::unique_lock lock(Mutex);
+			for (auto& [ch, slot] : slots)
+			{
+				slot->FrameNumber = 0;
+				ch->WritePool.push_front(slot);
+			}
+		}
+		WriteCV.notify_all();
+	}
+
+	ResourceInterface::ResourceBase* BeginPop(Channel& ch, uint64_t timeoutMs)
+	{
+		std::unique_lock lock(Mutex);
+		if (!ReadCV.wait_for(lock, std::chrono::milliseconds(timeoutMs),
+							 [&] { return !ch.ReadPool.empty() || Exit; }))
+			return nullptr;
+		if (Exit)
+			return nullptr;
+		auto* slot = ch.ReadPool.front();
+		ch.ReadPool.pop_front();
+		return slot;
+	}
+
+	void EndPop(Channel& ch, ResourceInterface::ResourceBase* slot)
+	{
+		{
+			std::unique_lock lock(Mutex);
+			slot->FrameNumber = 0;
+			ch.WritePool.push_back(slot);
+		}
+		WriteCV.notify_all();
+	}
+};
+
+} // namespace nos

--- a/Plugins/nosResource/Source/MultiRingBuffer.cpp
+++ b/Plugins/nosResource/Source/MultiRingBuffer.cpp
@@ -1,0 +1,718 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#pragma once
+
+#include <set>
+
+#include <Nodos/Plugin.hpp>
+
+// External
+#include <glm/glm.hpp>
+#include <nosSysVulkan/Helpers.hpp>
+
+#include "MultiRing.h"
+#include "Ring.h"
+
+namespace nos::resource
+{
+
+struct MultiRingBufferNodeContext : NodeContext
+{
+	using RingMode = RingNodeBase::RingMode;
+	using OnRestartType = RingNodeBase::OnRestartType;
+
+	static constexpr std::string_view CHANNEL_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+	enum MenuCommandType : uint8_t
+	{
+		ADD_CHANNEL = 0,
+		REMOVE_CHANNEL = 1,
+	};
+
+	struct MenuCommand
+	{
+		MenuCommandType Type;
+		uint8_t Letter;
+		MenuCommand(uint32_t cmd)
+		{
+			Type = static_cast<MenuCommandType>(cmd & 0xFF);
+			Letter = static_cast<uint8_t>((cmd >> 8) & 0xFF);
+		}
+		MenuCommand(MenuCommandType type, uint8_t letter) : Type(type), Letter(letter) {}
+		operator uint32_t() const { return (Letter << 8) | Type; }
+	};
+
+	struct Channel
+	{
+		char Letter;
+		nos::Name InputName;
+		nos::Name OutputName;
+		uuid InputId{};
+		uuid OutputId{};
+		nos::TypeInfo TypeInfo;
+		MultiRing::Channel* RingChannel = nullptr;
+		std::atomic_bool IsOutLive = false;
+		ResourceInterface::ResourceBase* LastPopped = nullptr;
+		bool NeedsRecreation = false;
+		std::size_t RemainingRepeatableCount = 0;
+
+		Channel(char letter)
+			: Letter(letter),
+			  InputName((std::string("Input_") + letter).c_str()),
+			  OutputName((std::string("Output_") + letter).c_str()),
+			  TypeInfo(NSN_Generic)
+		{
+		}
+	};
+
+	std::map<char, std::unique_ptr<Channel>> Channels;
+	std::unordered_map<uuid, char> PinIdToLetter;
+	MultiRing Ring;
+	// Channels popped since the last SendScheduleRequest. One producer run
+	// pushes one slot per live channel, so we must only schedule again once
+	// every live channel has been popped — otherwise schedule requests pile
+	// up by a factor of N (channels) per consumer tick.
+	std::set<char> PoppedSinceLastSchedule;
+
+	OnRestartType OnRestart = OnRestartType::WAIT_UNTIL_FULL;
+	std::optional<uint32_t> RequestedRingSize = std::nullopt;
+	std::atomic<RingMode> Mode = RingMode::CONSUME;
+	std::condition_variable ModeCV;
+	std::mutex ModeMutex;
+	std::atomic_bool RepeatWhenFilling = false;
+
+	std::string GetName() const { return "MultiRingBuffer"; }
+
+	static std::optional<char> ParseLetter(std::string_view pinName)
+	{
+		auto pos = pinName.find_last_of('_');
+		if (pos == std::string::npos || pos + 2 != pinName.size())
+			return std::nullopt;
+		char c = pinName[pos + 1];
+		if (c < 'A' || c > 'Z')
+			return std::nullopt;
+		return c;
+	}
+
+	static bool IsInputPin(std::string_view pinName) { return pinName.starts_with("Input_"); }
+	static bool IsOutputPin(std::string_view pinName) { return pinName.starts_with("Output_"); }
+
+	using NodeContext::NodeContext;
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		std::vector<uuid> pinsToUnorphan;
+		for (auto* pin : *node->pins())
+		{
+			auto pinNameSv = pin->name()->string_view();
+			if (!IsInputPin(pinNameSv) && !IsOutputPin(pinNameSv))
+				continue;
+			auto letter = ParseLetter(pinNameSv);
+			if (!letter)
+				continue;
+
+			auto& channel = Channels[*letter];
+			if (!channel)
+				channel = std::make_unique<Channel>(*letter);
+
+			if (IsInputPin(pinNameSv))
+				channel->InputId = uuid(*pin->id());
+			else
+			{
+				channel->OutputId = uuid(*pin->id());
+				channel->IsOutLive = pin->live();
+			}
+			PinIdToLetter[uuid(*pin->id())] = *letter;
+
+			nos::Name typeName(pin->type_name()->c_str());
+			if (typeName != NSN_Generic && channel->TypeInfo->TypeName == NSN_Generic)
+				channel->TypeInfo = nos::TypeInfo(typeName);
+
+			if (auto orphanState = pin->orphan_state())
+				if (orphanState->type() == fb::PinOrphanStateType::ORPHAN)
+					pinsToUnorphan.push_back(uuid(*pin->id()));
+		}
+
+		for (auto& [_, ch] : Channels)
+			InitChannel(*ch);
+
+		for (auto const& pinId : pinsToUnorphan)
+			SetPinOrphanState(pinId, fb::PinOrphanStateType::ACTIVE);
+
+		AddPinValueWatcher(NSN_Size, [this](nos::Buffer const& newSize, std::optional<nos::Buffer> oldVal) {
+			uint32_t size = *newSize.As<uint32_t>();
+			if (oldVal && oldVal == newSize)
+				return;
+			RequestRingResize(size);
+		});
+		AddPinObjectWatcher(NSN_Alignment, [this](ObjectRef newAlignment, std::optional<ObjectRef>) {
+			bool any = false;
+			for (auto& [_, ch] : Channels)
+			{
+				if (!ch->RingChannel)
+					continue;
+				if (ch->RingChannel->ResInterface->CheckNewResource(NSN_Alignment, newAlignment))
+				{
+					nosEngine.SendPathRestart(ch->InputId);
+					ch->NeedsRecreation = true;
+					any = true;
+				}
+			}
+			if (any)
+			{
+				Ring.Stop();
+				PoppedSinceLastSchedule.clear();
+			}
+		});
+		AddPinValueWatcher(NOS_NAME_STATIC("RepeatWhenFilling"),
+						   [this](nos::Buffer const& newVal, std::optional<nos::Buffer> oldVal) {
+							   RepeatWhenFilling = *newVal.As<bool>();
+						   });
+		return NOS_RESULT_SUCCESS;
+	}
+
+	~MultiRingBufferNodeContext() override
+	{
+		for (auto& [_, ch] : Channels)
+			NOS_SOFT_CHECK(ch->LastPopped == nullptr);
+		Ring.Stop();
+	}
+
+	void InitChannel(Channel& ch)
+	{
+		std::shared_ptr<ResourceInterface> resource;
+		if (ch.TypeInfo->TypeName == NOS_NAME(sys::vulkan::Buffer::GetFullyQualifiedName()))
+			resource = std::make_shared<GPUBufferResource>();
+		else if (ch.TypeInfo->TypeName == NOS_NAME(sys::vulkan::Texture::GetFullyQualifiedName()))
+			resource = std::make_shared<GPUTextureResource>();
+		else
+			resource = std::make_shared<PODResource>();
+
+		ch.RingChannel = &Ring.AddChannel(ch.Letter, std::move(resource), &ch);
+
+		Channel* chPtr = &ch;
+		AddPinObjectWatcher(ch.InputName, [this, chPtr](ObjectRef newObj, std::optional<ObjectRef>) {
+			if (!chPtr->RingChannel)
+				return;
+			if (chPtr->RingChannel->ResInterface->CheckNewResource(NSN_Input, newObj))
+			{
+				nosEngine.SendPathRestart(chPtr->InputId);
+				Ring.Stop();
+				PoppedSinceLastSchedule.clear();
+				chPtr->NeedsRecreation = true;
+			}
+		});
+	}
+
+	Channel* GetChannelByPinId(uuid const& id)
+	{
+		auto it = PinIdToLetter.find(id);
+		if (it == PinIdToLetter.end())
+			return nullptr;
+		auto chIt = Channels.find(it->second);
+		return chIt != Channels.end() ? chIt->second.get() : nullptr;
+	}
+
+	void SeedOutputPin(Channel& ch)
+	{
+		if (!ch.RingChannel || ch.RingChannel->Resources.empty())
+			return;
+		auto* base = ch.RingChannel->Resources[0].get();
+		if (!base)
+			return;
+		if (ch.TypeInfo->TypeName == NOS_NAME(sys::vulkan::Buffer::GetFullyQualifiedName()))
+		{
+			if (auto* res = ResourceInterface::GetResource<GPUBufferResource>(base))
+				SetPinObject(ch.OutputName, res->BufObj);
+		}
+		else if (ch.TypeInfo->TypeName == NOS_NAME(sys::vulkan::Texture::GetFullyQualifiedName()))
+		{
+			if (auto* res = ResourceInterface::GetResource<GPUTextureResource>(base))
+				SetPinObject(ch.OutputName, res->TexObj);
+		}
+	}
+
+	void RequestRingResize(uint32_t size)
+	{
+		if (size == 0)
+		{
+			nosEngine.LogW((GetName() + " size cannot be 0").c_str());
+			return;
+		}
+		if (Ring.Size == size && (!RequestedRingSize.has_value() || *RequestedRingSize == size))
+			return;
+		for (auto& [_, ch] : Channels)
+		{
+			if (!ch->RingChannel)
+				continue;
+			nosPathCommand ringSizeChange{.Event = NOS_RING_SIZE_CHANGE, .RingSize = size};
+			nosEngine.SendPathCommand(ch->InputId, ringSizeChange);
+		}
+		Ring.Stop();
+		PoppedSinceLastSchedule.clear();
+		SendPathRestart();
+		RequestedRingSize = size;
+	}
+
+	void SendPathRestart()
+	{
+		for (auto& [_, ch] : Channels)
+			nosEngine.SendPathRestart(ch->InputId);
+	}
+
+	nosResult OnResolvePinDataTypes(nosResolvePinDataTypesParams* params) override
+	{
+		auto pinNameStr = nos::Name(params->InstigatorPinName).AsString();
+		auto letter = ParseLetter(pinNameStr);
+		if (!letter)
+			return NOS_RESULT_FAILED;
+		auto chIt = Channels.find(*letter);
+		if (chIt == Channels.end())
+			return NOS_RESULT_FAILED;
+		auto& ch = *chIt->second;
+		if (ch.TypeInfo->TypeName != NSN_Generic)
+			return NOS_RESULT_FAILED;
+		ch.TypeInfo = nos::TypeInfo(params->IncomingTypeName);
+		// Drop the Generic-fallback ring channel so OnPinUpdated re-inits with the resolved type.
+		if (ch.RingChannel)
+		{
+			Ring.Stop();
+			PoppedSinceLastSchedule.clear();
+			Ring.RemoveChannel(*letter);
+			ch.RingChannel = nullptr;
+		}
+		for (size_t i = 0; i < params->PinCount; i++)
+		{
+			auto& pinInfo = params->Pins[i];
+			if (pinInfo.Id == ch.InputId || pinInfo.Id == ch.OutputId)
+				pinInfo.OutResolvedTypeName = ch.TypeInfo->TypeName;
+		}
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinUpdated(const nosPinUpdate*) override
+	{
+		for (auto& [_, ch] : Channels)
+			if (!ch->RingChannel)
+				InitChannel(*ch);
+	}
+
+	void OnNodeUpdated(nosNodeUpdate const* update) override
+	{
+		if (update->Type == NOS_NODE_UPDATE_PIN_DELETED)
+		{
+			auto it = PinIdToLetter.find(update->PinDeleted);
+			if (it == PinIdToLetter.end())
+				return;
+			char letter = it->second;
+			PinIdToLetter.erase(it);
+			auto chIt = Channels.find(letter);
+			if (chIt == Channels.end())
+				return;
+			auto& ch = *chIt->second;
+			bool inputAlive = PinIdToLetter.contains(ch.InputId);
+			bool outputAlive = PinIdToLetter.contains(ch.OutputId);
+			if (!inputAlive && !outputAlive)
+			{
+				if (ch.RingChannel)
+				{
+					Ring.RemoveChannel(letter);
+					ch.RingChannel = nullptr;
+				}
+				Channels.erase(chIt);
+			}
+		}
+		else if (update->Type == NOS_NODE_UPDATE_PIN_CREATED)
+		{
+			auto* pin = update->PinCreated;
+			auto sv = pin->name()->string_view();
+			if (!IsInputPin(sv) && !IsOutputPin(sv))
+				return;
+			auto letter = ParseLetter(sv);
+			if (!letter)
+				return;
+			auto& chPtr = Channels[*letter];
+			if (!chPtr)
+				chPtr = std::make_unique<Channel>(*letter);
+			if (IsInputPin(sv))
+				chPtr->InputId = uuid(*pin->id());
+			else
+			{
+				chPtr->OutputId = uuid(*pin->id());
+				chPtr->IsOutLive = pin->live();
+			}
+			PinIdToLetter[uuid(*pin->id())] = *letter;
+			if (!chPtr->RingChannel)
+				InitChannel(*chPtr);
+		}
+	}
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		if (Channels.empty() || Ring.Exit)
+			return NOS_RESULT_FAILED;
+
+		uint32_t requestedSize = *params.GetPinValue<uint32_t>(NSN_Size);
+
+		struct Gathered
+		{
+			Channel* NodeCh;
+			MultiRing::Channel* RingCh;
+			ObjectRef Input;
+		};
+		std::vector<Gathered> gathered;
+		gathered.reserve(Channels.size());
+		std::vector<MultiRing::Channel*> wantedRings;
+		wantedRings.reserve(Channels.size());
+
+		uint32_t maxRequired = requestedSize;
+		for (auto& [_, ch] : Channels)
+		{
+			if (!ch->RingChannel || ch->RingChannel->Resources.empty() || !ch->TypeInfo)
+				continue;
+			auto it = params.find(ch->InputName);
+			if (it == params.end())
+				continue;
+			ObjectRef input = ch->RingChannel->ResInterface->ValidateAndGetPinObject(it->second, true);
+			if (!input.IsValid())
+				continue;
+			uint32_t required = ch->RingChannel->ResInterface->GetRequiredRingSize(input, requestedSize);
+			if (required > maxRequired)
+				maxRequired = required;
+			gathered.push_back({ch.get(), ch->RingChannel, input});
+			wantedRings.push_back(ch->RingChannel);
+		}
+		if (gathered.empty())
+		{
+			SendScheduleRequest(0);
+			return NOS_RESULT_FAILED;
+		}
+
+		bool effectiveSizeAdjusted = maxRequired != requestedSize;
+		ClearNodeStatusMessages();
+
+		if (Ring.Size != maxRequired)
+		{
+			if (effectiveSizeAdjusted)
+				nosEngine.LogW("Required ring size for this data type is %lu, will resize it", maxRequired);
+			RequestRingResize(maxRequired);
+			return NOS_RESULT_FAILED;
+		}
+
+		std::vector<MultiRing::SlotPair> slots;
+		if (!Ring.BeginPushSubset(100, wantedRings, slots))
+			return Ring.Exit ? NOS_RESULT_FAILED : NOS_RESULT_PENDING;
+
+		// Push outside the lock — Vulkan command recording can be slow.
+		for (size_t i = 0; i < gathered.size(); ++i)
+		{
+			auto& g = gathered[i];
+			auto* slot = slots[i].second;
+			g.RingCh->ResInterface->Push(slot, g.Input, params,
+										 NOS_NAME_STATIC("MultiRingBuffer"), true);
+			if (!g.NodeCh->IsOutLive)
+			{
+				ChangePinLiveness(g.NodeCh->OutputName, true);
+				g.NodeCh->IsOutLive = true;
+			}
+		}
+
+		Ring.EndPushAll(slots);
+
+		if (Mode == RingMode::FILL)
+		{
+			bool isFillComplete = true;
+			for (auto* rc : wantedRings)
+				if (Ring.WritePoolSize(*rc) != 0)
+				{
+					isFillComplete = false;
+					break;
+				}
+			if (isFillComplete)
+			{
+				Mode = RingMode::CONSUME;
+				ModeCV.notify_all();
+			}
+		}
+
+		return NOS_RESULT_SUCCESS;
+	}
+
+	nosResult CopyFrom(nosCopyFromInfo* cpy) override
+	{
+		auto* ch = GetChannelByPinId(cpy->ID);
+		if (!ch || !ch->RingChannel || Ring.Exit)
+			return NOS_RESULT_FAILED;
+		if (!ch->IsOutLive)
+			return NOS_RESULT_SUCCESS;
+
+		// EndPop the previous frame's slot before popping a new one. We can't
+		// rely on OnEndFrame: the engine only fires it on the path's primary
+		// source pin, so live secondary outputs (e.g. a second channel feeding
+		// the same consumer) never receive it. By the time the consumer asks
+		// for the next frame on this pin, it's done with the previous one.
+		if (ch->LastPopped)
+		{
+			Ring.EndPop(*ch->RingChannel, ch->LastPopped);
+			ch->LastPopped = nullptr;
+		}
+
+		if (OnRestart == OnRestartType::WAIT_UNTIL_FULL && RepeatWhenFilling)
+		{
+			if (ch->RemainingRepeatableCount > 0)
+			{
+				ch->RingChannel->ResInterface->OnRepeatPinValue(cpy);
+				ch->RemainingRepeatableCount--;
+				return NOS_RESULT_SUCCESS;
+			}
+		}
+		else if (Mode == RingMode::FILL)
+		{
+			std::unique_lock lock(ModeMutex);
+			if (!ModeCV.wait_for(lock, std::chrono::milliseconds(100),
+								 [this] { return Mode != RingMode::FILL; }))
+				return NOS_RESULT_PENDING;
+		}
+
+		ResourceInterface::ResourceBase* slot;
+		{
+			ScopedProfilerEvent _({.Name = "Wait For Filled Slot"});
+			slot = Ring.BeginPop(*ch->RingChannel, 100);
+		}
+		if (!slot)
+			return Ring.Exit ? NOS_RESULT_FAILED : NOS_RESULT_PENDING;
+
+		ObjectRef outPinObj{};
+		bool changePinValue = ch->RingChannel->ResInterface->BeginCopyFrom(slot, *cpy->PinObjectHandle, outPinObj);
+		if (changePinValue)
+			SetPinObject(ch->OutputName, outPinObj);
+
+		ch->RingChannel->ResInterface->WaitForDownloadToEnd(slot, "MultiRingBuffer", NodeName.AsString(), cpy);
+
+		cpy->ShouldSetSourceFrameNumber = true;
+		cpy->FrameNumber = slot->FrameNumber;
+
+		ch->LastPopped = slot;
+
+		PoppedSinceLastSchedule.insert(ch->Letter);
+		size_t liveCount = 0;
+		for (auto& [_, c] : Channels)
+			if (c->IsOutLive)
+				++liveCount;
+		if (PoppedSinceLastSchedule.size() >= liveCount)
+		{
+			SendScheduleRequest(1);
+			PoppedSinceLastSchedule.clear();
+		}
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnEndFrame(uuid const& pinId, nosEndFrameCause cause) override
+	{
+		auto* ch = GetChannelByPinId(pinId);
+		if (!ch)
+			return;
+
+		if (cause == NOS_END_FRAME_FAILED)
+		{
+			if (pinId == ch->OutputId)
+				return;
+			if (!ch->IsOutLive)
+				return;
+			ChangePinLiveness(ch->OutputName, false);
+			ch->IsOutLive = false;
+		}
+		// EndPop happens at the start of the next CopyFrom for this channel
+		// rather than here, because OnEndFrame is unreliable for secondary
+		// live outputs.
+	}
+
+	void SendScheduleRequest(uint32_t count, bool reset = false) const
+	{
+		nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = count, .Reset = reset};
+		nosEngine.ScheduleNode(&schedule);
+	}
+
+	void OnPathCommand(const nosPathCommand* command) override
+	{
+		switch (command->Event)
+		{
+		case NOS_RING_SIZE_CHANGE:
+			if (command->RingSize == 0)
+				return;
+			RequestedRingSize = command->RingSize;
+			nosEngine.SetPinValue(*GetPinId(NSN_Size), nos::Buffer::From(command->RingSize));
+			break;
+		default: return;
+		}
+	}
+
+	void OnPathStop() override
+	{
+		if (OnRestart == OnRestartType::WAIT_UNTIL_FULL)
+			Mode = RingMode::FILL;
+		for (auto& [_, ch] : Channels)
+		{
+			if (ch->LastPopped && ch->RingChannel)
+			{
+				Ring.EndPop(*ch->RingChannel, ch->LastPopped);
+				ch->LastPopped = nullptr;
+			}
+		}
+		Ring.Stop();
+		PoppedSinceLastSchedule.clear();
+	}
+
+	void OnPathStart() override
+	{
+		if (Channels.empty())
+			return;
+
+		PoppedSinceLastSchedule.clear();
+
+		if (OnRestart == OnRestartType::RESET || RepeatWhenFilling)
+			Ring.ResetAll(false);
+		else
+		{
+			for (auto& [_, ch] : Channels)
+				if (ch->RingChannel)
+					Ring.MoveOneReadToWriteIfFull(*ch->RingChannel);
+		}
+
+		if (RequestedRingSize)
+		{
+			Ring.ResizeAll(*RequestedRingSize);
+			for (auto& [_, ch] : Channels)
+				ch->NeedsRecreation = false;
+			RequestedRingSize = std::nullopt;
+		}
+		for (auto& [_, ch] : Channels)
+		{
+			if (ch->NeedsRecreation && ch->RingChannel)
+			{
+				Ring.RecreateChannelResources(*ch->RingChannel);
+				ch->NeedsRecreation = false;
+			}
+		}
+
+		size_t totalSchedule = 0;
+		for (auto& [_, ch] : Channels)
+		{
+			if (!ch->RingChannel)
+				continue;
+			if (ch->RingChannel->Resources.empty())
+			{
+				totalSchedule = std::max<size_t>(totalSchedule, 1);
+				continue;
+			}
+			auto emptySlotCount = Ring.WritePoolSize(*ch->RingChannel);
+			if (RepeatWhenFilling)
+				ch->RemainingRepeatableCount = std::max(emptySlotCount, (size_t)1) - 1;
+			totalSchedule = std::max(totalSchedule, emptySlotCount);
+			ch->RingChannel->ResInterface->OnPathStart();
+			SeedOutputPin(*ch);
+		}
+		Ring.Start();
+		if (totalSchedule > 0)
+		{
+			nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = (uint32_t)totalSchedule};
+			nosEngine.ScheduleNode(&schedule);
+		}
+	}
+
+	void OnNodeMenuRequested(nosContextMenuRequestPtr request) override
+	{
+		flatbuffers::FlatBufferBuilder fbb;
+		std::vector items = {
+			nos::CreateContextMenuItemDirect(fbb, "Add Channel", MenuCommand(ADD_CHANNEL, 0))};
+		HandleEvent(CreateAppEvent(fbb, app::CreateAppContextMenuUpdateDirect(
+											fbb, request->item_id(), request->pos(), request->instigator(), &items)));
+	}
+
+	void OnPinMenuRequested(nos::Name pinName, nosContextMenuRequestPtr request) override
+	{
+		auto sv = pinName.AsString();
+		if (!IsInputPin(sv) && !IsOutputPin(sv))
+			return;
+		auto letter = ParseLetter(sv);
+		if (!letter)
+			return;
+		if (Channels.size() <= 1)
+			return;
+		flatbuffers::FlatBufferBuilder fbb;
+		std::vector items = {nos::CreateContextMenuItemDirect(
+			fbb, "Remove Channel", MenuCommand(REMOVE_CHANNEL, static_cast<uint8_t>(*letter)))};
+		HandleEvent(CreateAppEvent(fbb, app::CreateAppContextMenuUpdateDirect(
+											fbb, request->item_id(), request->pos(), request->instigator(), &items)));
+	}
+
+	void OnMenuCommand(uuid const& itemID, uint32_t cmd) override
+	{
+		auto command = MenuCommand(cmd);
+		switch (command.Type)
+		{
+		case ADD_CHANNEL:
+		{
+			char newLetter = 0;
+			for (char c : CHANNEL_LETTERS)
+			{
+				if (!Channels.contains(c))
+				{
+					newLetter = c;
+					break;
+				}
+			}
+			if (newLetter == 0)
+			{
+				SetNodeStatusMessage("Maximum number of channels reached", fb::NodeStatusMessageType::WARNING);
+				return;
+			}
+
+			fb::TPin inPin;
+			inPin.id = uuid(nosEngine.GenerateID());
+			inPin.name = std::string("Input_") + newLetter;
+			inPin.type_name = "nos.Generic";
+			inPin.show_as = fb::ShowAs::INPUT_PIN;
+			inPin.can_show_as = fb::CanShowAs::INPUT_PIN_ONLY;
+
+			fb::TPin outPin;
+			outPin.id = uuid(nosEngine.GenerateID());
+			outPin.name = std::string("Output_") + newLetter;
+			outPin.type_name = "nos.Generic";
+			outPin.show_as = fb::ShowAs::OUTPUT_PIN;
+			outPin.can_show_as = fb::CanShowAs::OUTPUT_PIN_ONLY;
+			outPin.live = true;
+
+			nos::TPartialNodeUpdate update;
+			update.node_id = NodeId;
+			update.pins_to_add.emplace_back(std::make_unique<fb::TPin>(std::move(inPin)));
+			update.pins_to_add.emplace_back(std::make_unique<fb::TPin>(std::move(outPin)));
+			flatbuffers::FlatBufferBuilder fbb;
+			HandleEvent(CreateAppEvent(fbb, nos::CreatePartialNodeUpdate(fbb, &update)));
+			break;
+		}
+		case REMOVE_CHANNEL:
+		{
+			char letter = static_cast<char>(command.Letter);
+			auto it = Channels.find(letter);
+			if (it == Channels.end())
+				return;
+			auto& ch = *it->second;
+			nos::TPartialNodeUpdate update;
+			update.node_id = NodeId;
+			update.pins_to_delete = {ch.InputId, ch.OutputId};
+			flatbuffers::FlatBufferBuilder fbb;
+			HandleEvent(CreateAppEvent(fbb, nos::CreatePartialNodeUpdate(fbb, &update)));
+			break;
+		}
+		}
+	}
+};
+
+nosResult RegisterMultiRingBuffer(nosNodeFunctions* functions)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("MultiRingBuffer"), MultiRingBufferNodeContext, functions)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::resource

--- a/Plugins/nosResource/Source/ResourceMain.cpp
+++ b/Plugins/nosResource/Source/ResourceMain.cpp
@@ -34,6 +34,8 @@ nosResult RegisterTexture2Buffer(nosNodeFunctions*);
 nosResult RegisterTextureProvider(nosNodeFunctions*);
 nosResult RegisterUploadBuffer(nosNodeFunctions*);
 nosResult RegisterUploadBufferProvider(nosNodeFunctions*);
+nosResult RegisterMultiRingBuffer(nosNodeFunctions*);
+nosResult RegisterMultiBoundedQueue(nosNodeFunctions*);
 }
 
 namespace nos::resource
@@ -58,6 +60,8 @@ enum class Nodes : size_t
 	TextureProvider,
 	UploadBuffer,
 	UploadBufferProvider,
+	MultiRingBuffer,
+	MultiBoundedQueue,
 	Count,
 };
 
@@ -101,6 +105,8 @@ nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outCount, nosNodeFunctions** o
 			GEN_CASE_NODE(TextureProvider)
 			GEN_CASE_NODE(UploadBuffer)
 			GEN_CASE_NODE(UploadBufferProvider)
+			GEN_CASE_NODE(MultiRingBuffer)
+			GEN_CASE_NODE(MultiBoundedQueue)
 		}
 	}
 

--- a/Plugins/nosStrings/Nodes/StringFormat.nosnode
+++ b/Plugins/nosStrings/Nodes/StringFormat.nosnode
@@ -1,0 +1,41 @@
+{
+	"nodes": [
+		{
+			"class_name": "StringFormat",
+			"menu_info": {
+				"category": "String",
+				"display_name": "String Format",
+				"hide_in_context_menu": false,
+				"name_aliases": [
+					"format",
+					"template",
+					"interpolate",
+					"sprintf",
+					"compose"
+				]
+			},
+			"node": {
+				"class_name": "StringFormat",
+				"contents_type": "Job",
+				"description": "Builds a string from a format expression. Each {name} placeholder opens an\ninput pin; an optional :spec uses std::format syntax and sets the pin type\n(integer for d/b/o/x/c, floating for e/f/g/%, string otherwise). Write\nliteral braces as {{ and }}.",
+				"display_name": "String Format",
+				"pins": [
+					{
+						"name": "Format",
+						"type_name": "string",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Format expression. Placeholders like {user} or {count:d} open input pins."
+					},
+					{
+						"name": "Output",
+						"type_name": "string",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "Formatted string"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosStrings/Source/StringFormat.cpp
+++ b/Plugins/nosStrings/Source/StringFormat.cpp
@@ -1,0 +1,339 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+// stl
+#include <format>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace nos::strings
+{
+// Placeholder syntax: "Hello {user}, you have {count:d} messages, ratio {ratio:.2f}".
+// Each unique {name} opens an input pin named after it. The optional ":spec" is a
+// std::format specification; the spec's presentation type determines the pin type:
+//   d b B o x X c          -> integer pin ("long")
+//   a A e E f F g G %       -> floating pin ("double")
+//   (none) / s / alignment  -> string pin ("string")
+// Literal braces are written as "{{" and "}}".
+
+static constexpr std::string_view RESERVED_PINS[] = { "Format", "Output" };
+
+enum class ArgType : uint8_t
+{
+	STRING,
+	INT,
+	DOUBLE,
+};
+
+static const char* TypeNameOf(ArgType type)
+{
+	switch (type)
+	{
+	case ArgType::INT:    return "long";
+	case ArgType::DOUBLE: return "double";
+	default:              return "string";
+	}
+}
+
+static ArgType InferType(std::string_view spec)
+{
+	if (spec.empty())
+		return ArgType::STRING;
+	char last = spec.back();
+	if (std::string_view("dbBoxXc").find(last) != std::string_view::npos)
+		return ArgType::INT;
+	if (std::string_view("aAeEfFgG%").find(last) != std::string_view::npos)
+		return ArgType::DOUBLE;
+	return ArgType::STRING;
+}
+
+static bool IsReserved(std::string_view name)
+{
+	for (auto reserved : RESERVED_PINS)
+		if (name == reserved)
+			return true;
+	return false;
+}
+
+static std::string Trim(std::string_view s)
+{
+	size_t b = s.find_first_not_of(" \t");
+	if (b == std::string_view::npos)
+		return {};
+	size_t e = s.find_last_not_of(" \t");
+	return std::string(s.substr(b, e - b + 1));
+}
+
+struct StringFormatNode : NodeContext
+{
+	struct Segment
+	{
+		bool IsLiteral = true;
+		std::string Literal;  // valid when IsLiteral
+		std::string Name;     // placeholder name (when !IsLiteral)
+		std::string Spec;     // std::format spec without the leading ':'
+		ArgType Type = ArgType::STRING;
+	};
+
+	std::string Format;
+	std::vector<Segment> Segments;
+	// Unique placeholder name -> resolved type (type is taken from its first occurrence).
+	std::unordered_map<std::string, ArgType> Placeholders;
+	std::string ParseError;
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		if (auto* pins = node->pins())
+		{
+			for (auto const* pin : *pins)
+			{
+				if (pin->name()->string_view() == "Format" && pin->data() && pin->data()->size() > 0)
+				{
+					Format = std::string(reinterpret_cast<const char*>(pin->data()->Data()));
+					break;
+				}
+			}
+		}
+		Parse();
+		UpdatePins();
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinValueChanged(nos::Name pinName, uuid const& pinId, nosBuffer value) override
+	{
+		if (pinName != NOS_NAME("Format"))
+			return;
+		std::string newFormat = value.Data ? static_cast<const char*>(value.Data) : "";
+		if (Format == newFormat)
+			return;
+		Format = std::move(newFormat);
+		Parse();
+		UpdatePins();
+	}
+
+	// Parse Format into Segments + the unique Placeholders map.
+	void Parse()
+	{
+		Segments.clear();
+		Placeholders.clear();
+		ParseError.clear();
+
+		std::string literal;
+		auto flushLiteral = [&]()
+		{
+			if (!literal.empty())
+			{
+				Segments.push_back({ true, literal, {}, {}, ArgType::STRING });
+				literal.clear();
+			}
+		};
+
+		for (size_t i = 0; i < Format.size();)
+		{
+			char c = Format[i];
+			if (c == '{')
+			{
+				if (i + 1 < Format.size() && Format[i + 1] == '{')
+				{
+					literal += '{';
+					i += 2;
+					continue;
+				}
+				size_t close = Format.find('}', i + 1);
+				if (close == std::string::npos)
+				{
+					ParseError = "Unterminated '{' in format string";
+					literal += Format.substr(i);
+					break;
+				}
+				std::string field = Format.substr(i + 1, close - (i + 1));
+				i = close + 1;
+
+				auto colon = field.find(':');
+				std::string name = Trim(colon == std::string::npos ? field : field.substr(0, colon));
+				std::string spec = colon == std::string::npos ? std::string() : field.substr(colon + 1);
+
+				if (name.empty())
+				{
+					ParseError = "Empty placeholder name in format string";
+					continue;
+				}
+				if (IsReserved(name))
+				{
+					ParseError = "Placeholder name '" + name + "' is reserved";
+					continue;
+				}
+
+				ArgType type = InferType(spec);
+				auto [it, inserted] = Placeholders.try_emplace(name, type);
+				if (!inserted)
+					type = it->second;  // first occurrence wins for typing
+
+				flushLiteral();
+				Segments.push_back({ false, {}, name, spec, type });
+			}
+			else if (c == '}')
+			{
+				if (i + 1 < Format.size() && Format[i + 1] == '}')
+				{
+					literal += '}';
+					i += 2;
+					continue;
+				}
+				literal += '}';
+				i += 1;
+			}
+			else
+			{
+				literal += c;
+				i += 1;
+			}
+		}
+		flushLiteral();
+	}
+
+	// Reconcile the dynamic input pins with the current set of placeholders.
+	void UpdatePins()
+	{
+		flatbuffers::FlatBufferBuilder fbb;
+		std::vector<flatbuffers::Offset<nos::fb::Pin>> pinsToAdd;
+		std::vector<flatbuffers::Offset<nos::PartialPinUpdate>> pinsToUpdate;
+		std::vector<nos::fb::UUID> pinsToDelete;
+
+		for (auto const& [name, type] : Placeholders)
+		{
+			nos::Name pinName(name.c_str());
+			if (auto* pin = GetPin(pinName))
+			{
+				if (pin->TypeName != nos::Name(TypeNameOf(type)) || pin->IsOrphan)
+				{
+					pinsToUpdate.push_back(CreatePartialPinUpdateDirect(
+						fbb,
+						&pin->Id,
+						0,
+						nos::fb::CreatePinOrphanStateDirect(fbb, fb::PinOrphanStateType::ACTIVE),
+						TypeNameOf(type),
+						name.c_str()));
+				}
+			}
+			else
+			{
+				uuid id = nosEngine.GenerateID();
+				std::vector<uint8_t> data = DefaultData(type);
+				pinsToAdd.push_back(fb::CreatePinDirect(
+					fbb,
+					&id,
+					name.c_str(),
+					TypeNameOf(type),
+					nos::fb::ShowAs::INPUT_PIN,
+					nos::fb::CanShowAs::INPUT_PIN_OR_PROPERTY,
+					0, &data));
+			}
+		}
+
+		// Delete dynamic pins that are no longer referenced by the format string.
+		for (auto const& [name, id] : PinName2Id)
+		{
+			if (IsReserved(name.AsString()))
+				continue;
+			if (!Placeholders.contains(name.AsString()))
+				pinsToDelete.push_back(id);
+		}
+
+		if (!pinsToAdd.empty() || !pinsToDelete.empty() || !pinsToUpdate.empty())
+		{
+			HandleEvent(CreateAppEvent(fbb, CreatePartialNodeUpdateDirect(
+				fbb, &NodeId, ClearFlags::NONE,
+				&pinsToDelete, &pinsToAdd, 0, 0, 0, 0, 0, &pinsToUpdate)));
+		}
+
+		UpdateStatus();
+	}
+
+	static std::vector<uint8_t> DefaultData(ArgType type)
+	{
+		switch (type)
+		{
+		case ArgType::INT:    return std::vector<uint8_t>(sizeof(int64_t), 0);
+		case ArgType::DOUBLE: return std::vector<uint8_t>(sizeof(double), 0);
+		default:              return std::vector<uint8_t>(1, 0);  // empty, null-terminated string
+		}
+	}
+
+	void UpdateStatus()
+	{
+		if (!ParseError.empty())
+		{
+			SetPinOrphanState(NOS_NAME("Output"), fb::PinOrphanStateType::ORPHAN, ParseError.c_str());
+			SetNodeStatusMessage(ParseError, fb::NodeStatusMessageType::FAILURE);
+		}
+		else
+		{
+			SetPinOrphanState(NOS_NAME("Output"), fb::PinOrphanStateType::ACTIVE);
+			ClearNodeStatusMessages();
+		}
+	}
+
+	std::string FormatValue(Segment const& seg, NodeExecuteParams const& pins)
+	{
+		nos::Name pinName(seg.Name.c_str());
+		auto it = pins.find(pinName);
+		std::string fmt = seg.Spec.empty() ? "{}" : "{:" + seg.Spec + "}";
+		const void* data = (it != pins.end() && it->second.Object) ? pins.GetPinBuffer(pinName).Data : nullptr;
+
+		switch (seg.Type)
+		{
+		case ArgType::INT:
+		{
+			int64_t v = data ? *static_cast<const int64_t*>(data) : 0;
+			return std::vformat(fmt, std::make_format_args(v));
+		}
+		case ArgType::DOUBLE:
+		{
+			double v = data ? *static_cast<const double*>(data) : 0.0;
+			return std::vformat(fmt, std::make_format_args(v));
+		}
+		default:
+		{
+			std::string v = data ? static_cast<const char*>(data) : "";
+			return std::vformat(fmt, std::make_format_args(v));
+		}
+		}
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& pins) override
+	{
+		if (!ParseError.empty())
+		{
+			SetNodeStatusMessage(ParseError, fb::NodeStatusMessageType::FAILURE);
+			return NOS_RESULT_FAILED;
+		}
+
+		std::string result;
+		try
+		{
+			for (auto const& seg : Segments)
+				result += seg.IsLiteral ? seg.Literal : FormatValue(seg, pins);
+		}
+		catch (std::format_error const& e)
+		{
+			std::string msg = std::string("Invalid format spec: ") + e.what();
+			SetNodeStatusMessage(msg, fb::NodeStatusMessageType::FAILURE);
+			return NOS_RESULT_FAILED;
+		}
+
+		SetPinValue(NOS_NAME("Output"), result.c_str());
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterStringFormat(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("StringFormat"), StringFormatNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::strings

--- a/Plugins/nosStrings/Source/StringsMain.cpp
+++ b/Plugins/nosStrings/Source/StringsMain.cpp
@@ -18,6 +18,7 @@ enum Nodes : int
 	Pin2Json,
 	Json2Pin,
 	Tokenizer,
+	StringFormat,
 	Count
 };
 
@@ -26,6 +27,7 @@ nosResult RegisterRegex(nosNodeFunctions*);
 nosResult RegisterPin2Json(nosNodeFunctions*);
 nosResult RegisterJson2Pin(nosNodeFunctions*);
 nosResult RegisterTokenizer(nosNodeFunctions*);
+nosResult RegisterStringFormat(nosNodeFunctions*);
 
 nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outSize, nosNodeFunctions** outList)
 {
@@ -52,6 +54,7 @@ nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outSize, nosNodeFunctions** ou
 			GEN_CASE_NODE(Pin2Json)
 			GEN_CASE_NODE(Json2Pin)
 			GEN_CASE_NODE(Tokenizer)
+			GEN_CASE_NODE(StringFormat)
 		}
 	}
 	return NOS_RESULT_SUCCESS;
@@ -62,7 +65,7 @@ extern "C"
 NOSAPI_ATTR nosResult NOSAPI_CALL nosExportPlugin(nosPluginFunctions* out)
 {
 	out->ExportNodeFunctions = ExportNodeFunctions;
-	out->GetRenamedTypes = [](nosName* outRenamedFrom, nosName* outRenamedTo, size_t* outSize) {
+	out->GetRenamedNodeClasses = [](nosName* outRenamedFrom, nosName* outRenamedTo, size_t* outSize) {
 		if (!outRenamedFrom)
 		{
 			*outSize = 4;

--- a/Plugins/nosStrings/Strings.nosplugin
+++ b/Plugins/nosStrings/Strings.nosplugin
@@ -2,7 +2,7 @@
     "info": {
         "id": {
             "name": "nos.str",
-            "version": "1.0.0"
+            "version": "1.1.0"
         },
         "display_name": "Strings",
         "description": "Collection of string manipulation nodes",

--- a/Plugins/nosStrings/Tests/StringFormat_Literal_Parity.nosa
+++ b/Plugins/nosStrings/Tests/StringFormat_Literal_Parity.nosa
@@ -1,0 +1,378 @@
+{
+  "info": {
+    "version": "1.4.0.b0",
+    "loaded_modules": [
+      {
+        "name": "nos.test",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nos.reflect",
+        "version": "3.0.0"
+      },
+      {
+        "name": "nos.str",
+        "version": "1.1.0"
+      }
+    ]
+  },
+  "graph": {
+    "id": "0ca69677-9c31-4662-9b93-afff25796353",
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "contents_type": "Graph",
+    "contents": {
+      "nodes": [
+        {
+          "id": "2716a0b8-e291-4bb4-9923-d3dc029ada9b",
+          "name": "Thread",
+          "class_name": "nos.Thread",
+          "pins": [
+            {
+              "id": "88578880-377c-4fa0-9fcd-4eafb4e9be56",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "live": true
+            },
+            {
+              "id": "b9401cdd-7554-4191-a8b9-7fe2684463e3",
+              "name": "Importance",
+              "type_name": "ulong",
+              "show_as": "PROPERTY",
+              "can_show_as": "PROPERTY_ONLY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 86,
+            "y": -94
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          },
+          "always_execute": true
+        },
+        {
+          "id": "c1ee74b1-dedc-42cc-a382-96b030ff88a3",
+          "name": "TestScheduler",
+          "class_name": "nos.test.TestScheduler",
+          "pins": [
+            {
+              "id": "f1f889dc-9c64-4c38-ada9-5f675ad05bd9",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "8fe58f58-9a07-475c-9ecd-bdfe47894e83",
+              "name": "Sink",
+              "type_name": "uint",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "089610dc-beea-46a3-9510-e7fb61e125b6",
+              "name": "FreeRun",
+              "type_name": "bool",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": false,
+              "def": false,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "e7499c80-620c-4973-871d-040f2695e582",
+              "name": "DeltaTime",
+              "type_name": "nos.fb.vec2u",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 1,
+                "y": 60
+              },
+              "def": {
+                "x": 1,
+                "y": 60
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 324,
+            "y": 7
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "2b93c4aa-7a12-4973-8ea4-73811fa7e09a",
+          "name": "Assert",
+          "class_name": "nos.test.Assert",
+          "pins": [
+            {
+              "id": "e318b7ee-3c6c-4722-b1fd-a2f259fdfbe0",
+              "name": "Behaviour",
+              "type_name": "nos.test.AssertionBehaviour",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "EXIT_WITH_STATUS_CODE",
+              "def": "EXIT_WITH_STATUS_CODE",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "34c24e32-526b-4780-bde2-57beee932654",
+              "name": "NumFramesToWait",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "ee6cdec2-dd84-4f02-a728-3f393ef0b75a",
+              "name": "FrameCount",
+              "type_name": "uint",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "2053afbb-c435-47ca-accf-5e57ee76dac8",
+              "name": "Condition",
+              "type_name": "bool",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "adf7e7ee-d189-4fbc-bad4-58e780b095fb",
+              "name": "NumFramesToAssertOver",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "min": 1
+            }
+          ],
+          "pos": {
+            "x": 93,
+            "y": 11
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "d2da15a7-4153-4ba7-9d70-cf9d49995043",
+          "name": "IsEqual",
+          "class_name": "nos.reflect.IsEqual",
+          "pins": [
+            {
+              "id": "083dfe18-10e0-4e2c-9f92-849d24cab19d",
+              "name": "A",
+              "type_name": "string",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "hello",
+              "def": "hello",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "d0cb3c69-e02d-4848-8083-5891d4feec69",
+              "name": "B",
+              "type_name": "string",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "hello",
+              "def": "hello",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "4ef9339d-5c4d-43f6-b330-bead1e3eb7c6",
+              "name": "IsEqual",
+              "type_name": "bool",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -105,
+            "y": 4
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "id": "737f4f27-e884-4e0e-8f65-b6bc32c68a14",
+          "name": "StringFormat",
+          "class_name": "nos.str.StringFormat",
+          "pins": [
+            {
+              "id": "5140d6ae-81d1-4fad-afa6-137686df00a9",
+              "name": "Format",
+              "type_name": "string",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": "hello",
+              "def": "hello"
+            },
+            {
+              "id": "430d5cdb-08f8-4aea-9d19-ec75fba336ae",
+              "name": "Output",
+              "type_name": "string",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -266,
+            "y": 14
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "from": "88578880-377c-4fa0-9fcd-4eafb4e9be56",
+          "to": "f1f889dc-9c64-4c38-ada9-5f675ad05bd9",
+          "id": "4f25a328-4b24-4ba3-b327-3b174edb9fde"
+        },
+        {
+          "from": "ee6cdec2-dd84-4f02-a728-3f393ef0b75a",
+          "to": "8fe58f58-9a07-475c-9ecd-bdfe47894e83",
+          "id": "523a4b86-a3e5-4957-b49f-7502102d59e8"
+        },
+        {
+          "from": "4ef9339d-5c4d-43f6-b330-bead1e3eb7c6",
+          "to": "2053afbb-c435-47ca-accf-5e57ee76dac8",
+          "id": "3786ff81-3ae1-441f-9165-3863a8427141"
+        },
+        {
+          "from": "430d5cdb-08f8-4aea-9d19-ec75fba336ae",
+          "to": "083dfe18-10e0-4e2c-9f92-849d24cab19d",
+          "id": "9840c47c-cdb6-49ee-9ca5-e979a957129a"
+        }
+      ]
+    },
+    "plugin_version": {
+      "major": 0,
+      "minor": 0,
+      "patch": 0
+    }
+  }
+}

--- a/Plugins/nosTrack/CMakeLists.txt
+++ b/Plugins/nosTrack/CMakeLists.txt
@@ -1,2 +1,7 @@
 # Copyright MediaZ Teknoloji A.S. All Rights Reserved.
 target_include_directories(${NOS_PLUGIN_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/External/asio/asio/include")
+
+# Expose the public Include/ folder (CoordinateFrameConversion.hpp) to this plugin
+# and to dependents (nos.graphics, nos.geometry) that consume the shared coordinate
+# helpers. The coordinate/transform types live here too (Types/Coordinates.fbs).
+target_include_directories(${NOS_PLUGIN_TARGET} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Include")

--- a/Plugins/nosTrack/Include/nosTrack/CoordinateFrameConversion.hpp
+++ b/Plugins/nosTrack/Include/nosTrack/CoordinateFrameConversion.hpp
@@ -1,0 +1,206 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+// Frame-conversion helpers for nos.graphics.CoordinateFrame, shared by the
+// graphics nodes (ConvertCoordinateFrame / TrackToTransformQ / CameraGuide),
+// the Track nodes (ConvertTrackFrame / RecordTrackCOLMAP / PlaybackTrackCOLMAP /
+// ConvertTransform) and transform producers such as nos.geometry's FBX reader.
+// Builds basis-change matrices from a CoordinateFrame's fields, encodes the
+// per-system Euler conventions, and converts to/from the COLMAP camera/world frame.
+#pragma once
+
+#include <nosTrack/Coordinates_generated.h>
+
+#ifndef GLM_ENABLE_EXPERIMENTAL
+#define GLM_ENABLE_EXPERIMENTAL
+#endif
+#include <glm/glm.hpp>
+#include <glm/gtx/euler_angles.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <cmath>
+
+namespace nos::track
+{
+
+using Frame = CoordinateFrame;
+
+// Euler encodings, used as the nested `euler` of the frame presets below.
+inline EulerEncoding const UNREAL_EULER{EulerOrder::ZYX, -1, -1, 1};
+inline EulerEncoding const OPENGL_EULER{EulerOrder::YXZ, 1, 1, 1};
+
+// Named frame presets matching CoordinateSystemPresets.json. COLMAP_SYSTEM is the
+// COLMAP camera/world frame (X right, Y down, Z forward, RH, meters); its basis
+// equals ColmapBasisMatrix() and it supplies meters_per_unit = 1.0 for unit conversion.
+inline CoordinateFrame const UNREAL_SYSTEM{SignedAxis::PosZ, SignedAxis::PosX, Handedness::LeftHanded,  UNREAL_EULER, 0.01};
+inline CoordinateFrame const GLTF_SYSTEM  {SignedAxis::PosY, SignedAxis::NegZ, Handedness::RightHanded, OPENGL_EULER, 1.0};
+inline CoordinateFrame const COLMAP_SYSTEM{SignedAxis::NegY, SignedAxis::PosZ, Handedness::RightHanded, OPENGL_EULER, 1.0};
+
+// A frame is usable iff forward and up name different axes; otherwise right =
+// forward x up is zero and BasisMatrix is singular (inverse -> NaN). Consumers
+// should reject invalid frames with a node error rather than emit NaN.
+inline bool CoordinateFrameValid(CoordinateFrame const& cs)
+{
+	// SignedAxis packs as {PosX,NegX,PosY,NegY,PosZ,NegZ}; /2 collapses sign to axis.
+	return (static_cast<int>(cs.forward()) / 2) != (static_cast<int>(cs.up()) / 2);
+}
+
+// Unit-conversion factor for a length expressed in `src` re-expressed in `tgt`:
+// src.meters_per_unit / tgt.meters_per_unit. Guards a non-positive source or
+// target scale (zero / negative / NaN) by returning 1.0 (no scaling, no mirrored
+// or collapsed world).
+inline double UnitFactor(CoordinateFrame const& src, CoordinateFrame const& tgt)
+{
+	double s = src.meters_per_unit();
+	double t = tgt.meters_per_unit();
+	if (!(s > 0.0) || !(t > 0.0))
+		return 1.0;
+	return s / t;
+}
+
+// Unit vector for a signed coordinate axis.
+inline glm::dvec3 AxisVec(SignedAxis a)
+{
+	switch (a)
+	{
+	case SignedAxis::PosX: return glm::dvec3( 1.0,  0.0,  0.0);
+	case SignedAxis::NegX: return glm::dvec3(-1.0,  0.0,  0.0);
+	case SignedAxis::PosY: return glm::dvec3( 0.0,  1.0,  0.0);
+	case SignedAxis::NegY: return glm::dvec3( 0.0, -1.0,  0.0);
+	case SignedAxis::PosZ: return glm::dvec3( 0.0,  0.0,  1.0);
+	case SignedAxis::NegZ: return glm::dvec3( 0.0,  0.0, -1.0);
+	}
+	return glm::dvec3(0.0);
+}
+
+// Basis matrix S for a CoordinateFrame: maps semantic (forward, right, up) to
+// engine coords. v_engine = S * (forward, right, up). Columns are (forward, right,
+// up); `right` is derived as forward x up, flipped for left-handed systems.
+// det(S) > 0 for left-handed frames, < 0 for right-handed (with this ordering).
+inline glm::dmat3 BasisMatrix(CoordinateFrame const& cs)
+{
+	glm::dvec3 fwd = AxisVec(cs.forward());
+	glm::dvec3 up = AxisVec(cs.up());
+	glm::dvec3 right = glm::cross(fwd, up);
+	if (cs.handedness() == Handedness::LeftHanded)
+		right = -right;
+	return glm::dmat3(fwd, right, up);
+}
+
+// COLMAP camera/world frame: X right, Y down, Z forward (RH). Provided as a basis
+// matrix in the same (forward, right, up) convention so it can be combined with
+// BasisMatrix to build cross-frame conversions.
+inline glm::dmat3 ColmapBasisMatrix()
+{
+	return glm::dmat3(
+		glm::dvec3( 0.0,  0.0,  1.0),  // forward -> +Z
+		glm::dvec3( 1.0,  0.0,  0.0),  // right -> +X
+		glm::dvec3( 0.0, -1.0,  0.0)); // up -> -Y (Y is down)
+}
+
+// Build a rotation matrix from Euler degrees per an EulerEncoding. Component i
+// contributes (sign_i * angle_i) about axis i, applied in `order` (intrinsic).
+// Independent of any frame's axis geometry -- it only decodes the three numbers.
+inline glm::dmat3 EulerToMat(EulerEncoding const& enc, glm::dvec3 const& degRot)
+{
+	glm::dvec3 r = glm::radians(degRot);
+	double x = enc.sign_x() * r.x;
+	double y = enc.sign_y() * r.y;
+	double z = enc.sign_z() * r.z;
+	switch (enc.order())
+	{
+	case EulerOrder::ZYX: return glm::dmat3(glm::eulerAngleZYX<double>(z, y, x));
+	case EulerOrder::XYZ: return glm::dmat3(glm::eulerAngleXYZ<double>(x, y, z));
+	case EulerOrder::YXZ: return glm::dmat3(glm::eulerAngleYXZ<double>(y, x, z));
+	case EulerOrder::YZX: return glm::dmat3(glm::eulerAngleYZX<double>(y, z, x));
+	case EulerOrder::ZXY: return glm::dmat3(glm::eulerAngleZXY<double>(z, x, y));
+	case EulerOrder::XZY: return glm::dmat3(glm::eulerAngleXZY<double>(x, z, y));
+	}
+	return glm::dmat3(1.0);
+}
+
+// Inverse of EulerToMat: extract Euler degrees in `enc`'s convention, packed into
+// the (rot.x, rot.y, rot.z) = (angle about X, Y, Z) layout. glm::extractEulerAngleABC
+// yields the angles in the same A,B,C axis order its name lists; we scatter them
+// back to (x, y, z) and undo the per-axis signs (sign in {-1,+1} so multiply).
+inline glm::dvec3 MatToEuler(EulerEncoding const& enc, glm::dmat3 const& R)
+{
+	glm::dmat4 M(R);
+	double t1 = 0.0, t2 = 0.0, t3 = 0.0;
+	glm::dvec3 ang(0.0);  // ang.x about X, ang.y about Y, ang.z about Z
+	switch (enc.order())
+	{
+	case EulerOrder::ZYX: glm::extractEulerAngleZYX(M, t1, t2, t3); ang = {t3, t2, t1}; break;
+	case EulerOrder::XYZ: glm::extractEulerAngleXYZ(M, t1, t2, t3); ang = {t1, t2, t3}; break;
+	case EulerOrder::YXZ: glm::extractEulerAngleYXZ(M, t1, t2, t3); ang = {t2, t1, t3}; break;
+	case EulerOrder::YZX: glm::extractEulerAngleYZX(M, t1, t2, t3); ang = {t3, t1, t2}; break;
+	case EulerOrder::ZXY: glm::extractEulerAngleZXY(M, t1, t2, t3); ang = {t2, t3, t1}; break;
+	case EulerOrder::XZY: glm::extractEulerAngleXZY(M, t1, t2, t3); ang = {t1, t3, t2}; break;
+	}
+	ang.x *= enc.sign_x();
+	ang.y *= enc.sign_y();
+	ang.z *= enc.sign_z();
+	return glm::degrees(ang);
+}
+
+// Basis-change M from `cs` to COLMAP frame: M = S_colmap * S_cs^-1.
+// For a vector:           v_colmap = M * v_cs.
+// For a rotation matrix:  R_colmap = M * R_cs * M^-1.
+inline glm::dmat3 BasisChangeToColmap(CoordinateFrame const& cs)
+{
+	return ColmapBasisMatrix() * glm::inverse(BasisMatrix(cs));
+}
+
+// Inverse of BasisChangeToColmap.
+inline glm::dmat3 BasisChangeFromColmap(CoordinateFrame const& cs)
+{
+	return BasisMatrix(cs) * glm::inverse(ColmapBasisMatrix());
+}
+
+// --- Shared geometric conversion core -----------------------------------------
+// One frame-to-frame conversion, precomputed: the basis change M (maps a vector
+// from `src` engine coords to `tgt` engine coords) and the position unit factor.
+// All three Convert* nodes build one of these and apply the helpers below, so the
+// geometry lives in exactly one place. Rotation handling (Euler vs quaternion) is
+// the only thing the nodes do differently.
+struct FrameConvert
+{
+	glm::dmat3 M{1.0};
+	double UnitFactor = 1.0;
+};
+
+inline FrameConvert MakeFrameConvert(CoordinateFrame const& src, CoordinateFrame const& tgt)
+{
+	FrameConvert f;
+	f.M = BasisMatrix(tgt) * glm::inverse(BasisMatrix(src));
+	f.UnitFactor = nos::track::UnitFactor(src, tgt);
+	return f;
+}
+
+// Position: basis change, then unit conversion.
+inline glm::dvec3 ConvertPosition(FrameConvert const& f, glm::dvec3 const& p)
+{
+	return f.M * p * f.UnitFactor;
+}
+
+// Rotation: conjugate by M (orthogonal => M^-1 = M^T). Preserves det(R) = 1, so a
+// handedness-flipping (improper) M still yields a proper rotation.
+inline glm::dmat3 ConvertRotation(FrameConvert const& f, glm::dmat3 const& R)
+{
+	return f.M * R * glm::transpose(f.M);
+}
+
+inline glm::dquat ConvertRotation(FrameConvert const& f, glm::dquat const& q)
+{
+	return glm::normalize(glm::quat_cast(ConvertRotation(f, glm::mat3_cast(q))));
+}
+
+// Scale: M is a signed axis permutation, so the per-axis factors just reorder.
+inline glm::dvec3 ConvertScale(FrameConvert const& f, glm::dvec3 const& s)
+{
+	glm::dmat3 absM(0.0);
+	for (int c = 0; c < 3; ++c)
+		for (int row = 0; row < 3; ++row)
+			absM[c][row] = std::abs(f.M[c][row]);
+	return absM * s;
+}
+
+}  // namespace nos::track

--- a/Plugins/nosTrack/Nodes/ConvertTrackFrame.nosnode
+++ b/Plugins/nosTrack/Nodes/ConvertTrackFrame.nosnode
@@ -1,0 +1,48 @@
+{
+	"nodes": [
+		{
+			"class_name": "ConvertTrackFrame",
+			"menu_info": {
+				"category": "Track|Coordinate System",
+				"display_name": "Convert Track Frame"
+			},
+			"node": {
+				"class_name": "ConvertTrackFrame",
+				"contents_type": "Job",
+				"description": "Transforms a Track between coordinate systems.\nThe Source and Target systems select axis assignments, handedness, units, and the Euler convention used for the rotation field.\nLocation: basis-changed (Source -> Target), then scaled by the ratio of the two systems' meters_per_unit (e.g. cm -> m yields 0.01).\nRotation: built in the source Euler convention, conjugated by the basis-change matrix, re-extracted in the target convention.\nOther Track fields (fov, focus, sensor_size, lens_distortion, ...) pass through unchanged.",
+				"pins": [
+					{
+						"name": "In",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "Source",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system convention (axes, handedness, units, Euler encoding) of the input Track."
+					},
+					{
+						"name": "Target",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+						"description": "Coordinate system convention (axes, handedness, units, Euler encoding) of the output Track."
+					},
+					{
+						"name": "Out",
+						"type_name": "nos.track.Track",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosTrack/Nodes/ConvertTransform.nosnode
+++ b/Plugins/nosTrack/Nodes/ConvertTransform.nosnode
@@ -1,0 +1,50 @@
+{
+	"nodes": [
+		{
+			"class_name": "ConvertTransform",
+			"menu_info": {
+				"category": "Track|Coordinate System",
+				"display_name": "Convert Transform"
+			},
+			"node": {
+				"class_name": "ConvertTransform",
+				"contents_type": "Job",
+				"description": "Converts a Transform between coordinate systems.\nThe Source and Target systems select axis assignments, handedness, units, and the Euler convention used for the rotation field.\nPosition: basis-changed (Source -> Target), then scaled by the ratio of the two systems' meters_per_unit (e.g. cm -> m yields 0.01).\nRotation: built in the source Euler convention, conjugated by the basis-change matrix, re-extracted in the target convention.\nScale: axis factors are reordered to follow the basis change.",
+				"pins": [
+					{
+						"name": "In",
+						"type_name": "nos.fb.Transform",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "SourceFrame",
+						"display_name": "Source Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system convention (axes, handedness, units, Euler encoding) of the input Transform."
+					},
+					{
+						"name": "TargetFrame",
+						"display_name": "Target Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+						"description": "Coordinate system convention (axes, handedness, units, Euler encoding) of the output Transform."
+					},
+					{
+						"name": "Out",
+						"type_name": "nos.fb.Transform",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_OR_PROPERTY"
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosTrack/Nodes/PlaybackTrackCOLMAP.nosnode
+++ b/Plugins/nosTrack/Nodes/PlaybackTrackCOLMAP.nosnode
@@ -1,0 +1,108 @@
+{
+	"nodes": [
+		{
+			"class_name": "PlaybackTrackCOLMAP",
+			"menu_info": {
+				"category": "nosTrack",
+				"display_name": "Playback Track (COLMAP)",
+				"name_aliases": [ "colmap", "import camera", "playback camera" ]
+			},
+			"node": {
+				"class_name": "PlaybackTrackCOLMAP",
+				"display_name": "Playback Track (COLMAP)",
+				"contents_type": "Job",
+				"always_execute": true,
+				"description": "Loads camera track from COLMAP-spec cameras.txt + images.txt.\nReads world-to-camera poses in the COLMAP frame (RH, +X right, +Y down, +Z forward) and converts to the chosen TargetFrame.\nWhen an extras.txt sidecar is present, original Euler/FOV/sensor metadata is restored verbatim (no quaternion round-trip drift).",
+				"pins": [
+					{
+						"name": "InputDirectory",
+						"display_name": "Input Directory",
+						"type_name": "string",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "FOLDER_PICKER" },
+						"description": "Directory with cameras.txt + images.txt (and optional timecodes.txt / extras.txt sidecars)."
+					},
+					{
+						"name": "TargetFrame",
+						"display_name": "Target Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system of the produced Track (axes, handedness, units, euler encoding).\nCOLMAP poses (meters) are converted into this system; the euler encoding is used when emitting the rotation.\nDefault matches FreeD / UE convention."
+					},
+					{
+						"name": "Mode",
+						"display_name": "Mode",
+						"type_name": "nos.track.PlaybackTrackMode",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": "FrameIndex",
+						"description": "Selects how to index frames.\nFrameIndex uses InFrameIndex.\nTimecode / FrameNumber look up via timecodes.txt sidecar.\nThe unused index pin becomes PASSIVE."
+					},
+					{
+						"name": "InFrameIndex",
+						"display_name": "Frame Index",
+						"type_name": "uint",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0,
+						"description": "0-based frame index. Used when Mode=FrameIndex."
+					},
+					{
+						"name": "InTimecode",
+						"display_name": "Timecode",
+						"type_name": "string",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Timecode string (HH:MM:SS:FF) to look up. Used when Mode=Timecode. Requires timecodes.txt."
+					},
+					{
+						"name": "InFrameNumber",
+						"display_name": "Frame Number",
+						"type_name": "uint",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0,
+						"description": "Absolute frame number to look up. Used when Mode=FrameNumber. Requires timecodes.txt."
+					},
+					{
+						"name": "OutFrameIndex",
+						"display_name": "Frame Index",
+						"type_name": "uint",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"data": 0,
+						"description": "Current playback frame index."
+					},
+					{
+						"name": "FrameCount",
+						"display_name": "Frame Count",
+						"type_name": "uint",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"data": 0,
+						"description": "Total frames loaded."
+					},
+					{
+						"name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "Track for the current frame, expressed in the TargetFrame convention."
+					}
+				],
+				"functions": [
+					{
+						"class_name": "PlaybackTrackCOLMAP_OpenFolder",
+						"display_name": "Open Folder",
+						"contents_type": "Job",
+						"pins": []
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosTrack/Nodes/ReOriginTrack.nosnode
+++ b/Plugins/nosTrack/Nodes/ReOriginTrack.nosnode
@@ -1,0 +1,79 @@
+{
+	"nodes": [
+		{
+			"class_name": "nos.track.ReOriginTrack",
+			"menu_info": {
+				"category": "Track|Coordinate System",
+				"display_name": "Re-Origin Track",
+				"name_aliases": [ "tare", "zero track", "set origin", "reorigin" ]
+			},
+			"node": {
+				"class_name": "nos.track.ReOriginTrack",
+				"display_name": "Re-Origin Track",
+				"contents_type": "Job",
+				"description": "Re-expresses the input track relative to a marked origin pose.\nClick Mark Origin to capture the current input pose as the reference;\noutput location/rotation then become the input pose in that origin's local frame\n(rigid-body relative: inverse(T_origin) * T_input). All other fields (fov, zoom,\nfocus, sensor, lens, ...) pass through unchanged. Until an origin is marked the\noutput equals the input. Set CoordinateSystem to match the connected track.",
+				"pins": [
+					{
+						"name": "Input",
+						"display_name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Camera track to re-origin. Interpreted in the CoordinateSystem convention\n(location, rotation Euler)."
+					},
+					{
+						"name": "CoordinateSystem",
+						"display_name": "Coordinate System",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system of the connected track (axes, handedness, euler encoding).\nUsed to decode/encode rotation when computing the relative pose.\nDefault matches FreeD / UE convention."
+					},
+					{
+						"name": "Origin",
+						"display_name": "Origin",
+						"type_name": "nos.track.Track",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"location": { "x": 0.0, "y": 0.0, "z": 0.0 },
+							"rotation": { "x": 0.0, "y": 0.0, "z": 0.0 },
+							"fov": 0.0, "zoom": 0.0, "focus": 0.0, "render_ratio": 0.0,
+							"sensor_size": { "x": 0.0, "y": 0.0 },
+							"pixel_aspect_ratio": 0.0, "nodal_offset": 0.0, "focus_distance": 0.0,
+							"lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 0.0 }
+						},
+						"meta_data_map": [
+							{ "key": "PinHidden", "value": "true" }
+						],
+						"description": "Marked origin pose. Captured by Mark Origin, reset by Clear Origin.\nHidden; persisted with the node so the origin survives save/reload."
+					},
+					{
+						"name": "Output",
+						"display_name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "Input track with location/rotation re-expressed relative to the marked origin.\nAll non-pose fields are passed through unchanged."
+					}
+				],
+				"functions": [
+					{
+						"class_name": "ReOriginTrack_MarkOrigin",
+						"display_name": "Mark Origin",
+						"contents_type": "Job",
+						"pins": []
+					},
+					{
+						"class_name": "ReOriginTrack_ClearOrigin",
+						"display_name": "Clear Origin",
+						"contents_type": "Job",
+						"pins": []
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosTrack/Nodes/RecordTrackCOLMAP.nosnode
+++ b/Plugins/nosTrack/Nodes/RecordTrackCOLMAP.nosnode
@@ -1,0 +1,121 @@
+{
+	"nodes": [
+		{
+			"class_name": "RecordTrackCOLMAP",
+			"menu_info": {
+				"category": "nosTrack",
+				"display_name": "Record Track (COLMAP)",
+				"name_aliases": [ "colmap", "export camera", "record camera" ]
+			},
+			"node": {
+				"class_name": "RecordTrackCOLMAP",
+				"display_name": "Record Track (COLMAP)",
+				"contents_type": "Job",
+				"always_execute": true,
+				"description": "Records camera track data each frame while Record is true.\nOn falling edge (after MinOffFrames debounce) writes COLMAP-spec cameras.txt + images.txt and clears the buffer.\nIntrinsics come from FOV/sensor/distortion. Extrinsics are written as world-to-camera in the COLMAP frame (RH, +X right, +Y down, +Z forward).\nSet SourceFrame to match the convention of the connected Track.",
+				"pins": [
+					{
+						"name": "Timecode",
+						"display_name": "Timecode",
+						"type_name": "string",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Optional SMPTE timecode (HH:MM:SS:FF). Written to timecodes.txt sidecar when non-empty."
+					},
+					{
+						"name": "FrameNumber",
+						"display_name": "Frame Number",
+						"type_name": "uint",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 0,
+						"description": "Optional absolute frame number paired with Timecode. Written to timecodes.txt sidecar."
+					},
+					{
+						"name": "OutputDirectory",
+						"display_name": "Output Directory",
+						"type_name": "string",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "FOLDER_PICKER" },
+						"description": "Where cameras.txt and images.txt are written when recording stops. Must be empty to start recording."
+					},
+					{
+						"name": "ImageResolution",
+						"display_name": "Image Resolution",
+						"type_name": "nos.fb.vec2u",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": {
+							"x": 1920,
+							"y": 1080
+						},
+						"description": "Image WIDTH/HEIGHT in pixels. Used to compute focal length and principal point for cameras.txt."
+					},
+					{
+						"name": "SourceFrame",
+						"display_name": "Source Frame",
+						"type_name": "nos.track.CoordinateFrame",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": { "type": "NAMED_VALUE", "name": "nos.track.CoordinateSystemPresets" },
+						"data": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+						"description": "Coordinate system of the connected Track (axes, handedness, units, euler encoding).\nUsed to convert location and rotation into the COLMAP frame (meters) before writing; the euler encoding is recorded into the extras sidecar.\nDefault matches FreeD / UE convention."
+					},
+					{
+						"name": "Record",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": false,
+						"description": "Drives recording.\nRising edge: clear buffer and start.\nFalling edge (after MinOffFrames): stop and write files.\nFails to start if OutputDirectory is non-empty."
+					},
+					{
+						"name": "MinOffFrames",
+						"display_name": "Min Off Frames",
+						"type_name": "uint",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 1,
+						"min": "1",
+						"description": "Debounce: minimum consecutive Record=false frames before stopping. Default 1 = stop immediately. Use 5-15 to ride out short upstream glitches (e.g. SDI bit flips on a camera-derived flag)."
+					},
+					{
+						"name": "RecordingFrame",
+						"display_name": "Recording Frame",
+						"type_name": "uint",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"data": 0,
+						"description": "Current recording frame index. 0 when not recording."
+					},
+					{
+						"name": "FrameCount",
+						"display_name": "Frame Count",
+						"type_name": "uint",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"data": 0,
+						"description": "Frames in the buffer."
+					},
+					{
+						"name": "InTrack",
+						"display_name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"description": "Camera track to record. Interpreted in the SourceFrame convention (location, rotation Euler, FOV, sensor, lens distortion)."
+					},
+					{
+						"name": "OutTrack",
+						"display_name": "Track",
+						"type_name": "nos.track.Track",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"description": "Pass-through of InTrack."
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosTrack/Nodes/UpdateTrackTransform.nosnode
+++ b/Plugins/nosTrack/Nodes/UpdateTrackTransform.nosnode
@@ -1,0 +1,1023 @@
+{ "nodes": [
+    {
+      "class_name": "nos.track.UpdateTrackTransform",
+			"menu_info": {
+				"category": "Track|Coordinate System",
+				"display_name": "Update Track Transform"
+			},
+      "node": {
+        "id": "01cdc9dd-13d7-48bf-af24-8bfa764451f3",
+        "name": "UpdateTrackTransform",
+        "class_name": "nos.track.UpdateTrackTransform",
+        "pins": [
+          {
+            "id": "fafae63e-ef87-4d1e-a3e9-2997515ae14a",
+            "name": "Input",
+            "type_name": "nos.track.Track",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": {
+              "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+              "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+              "fov": 74.0,
+              "render_ratio": 1.0,
+              "sensor_size": { "x": 9.59, "y": 5.394 },
+              "pixel_aspect_ratio": 1.0,
+              "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+            },
+            "def": {
+              "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+              "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+              "fov": 74.0,
+              "render_ratio": 1.0,
+              "sensor_size": { "x": 9.59, "y": 5.394 },
+              "pixel_aspect_ratio": 1.0,
+              "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+            },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "66c23108-61e0-410f-879e-a8be578cbffa" }
+          },
+          {
+            "id": "1e206698-7549-4cbc-8f69-e1796a7828c0",
+            "name": "Output",
+            "type_name": "nos.track.Track",
+            "show_as": "OUTPUT_PIN",
+            "can_show_as": "OUTPUT_PIN_ONLY",
+            "visualizer": {
+            },
+            "data": {
+              "location": { "x": 1.797839, "y": 2.031795, "z": 1.719097 },
+              "rotation": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+              "fov": 74.0,
+              "zoom": 0.0,
+              "focus": 0.0,
+              "render_ratio": 1.0,
+              "sensor_size": { "x": 9.59, "y": 5.394 },
+              "pixel_aspect_ratio": 1.0,
+              "nodal_offset": 0.0,
+              "focus_distance": 0.0,
+              "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+            },
+            "def": {
+              "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+              "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+              "fov": 74.0,
+              "render_ratio": 1.0,
+              "sensor_size": { "x": 9.59, "y": 5.394 },
+              "pixel_aspect_ratio": 1.0,
+              "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+            },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "6315f140-ca41-4744-9ccd-c1327ec8f8fb" },
+            "connection_conditions": "!array"
+          },
+          {
+            "id": "0efb4000-a3b6-49c0-9f1d-f9a7d0ace9c5",
+            "name": "Input (1)",
+            "type_name": "nos.track.TransformQ",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+            },
+            "data": { "position": { "x": 1.797839413158, "y": 2.03179492706, "z": 1.719097147995 }, "rotation": { "x": 0.051124280864, "y": -0.081418113625, "z": 0.842818976702, "w": -0.52954090606 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+            "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "scale": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+            "contents_type": "PortalPin",
+            "contents": { "source_id": "7fca9817-ae9e-44f6-80a0-b89c94a65e6c" }
+          }
+        ],
+        "pos": { "x": 0.0, "y": 0.0 },
+        "contents_type": "Graph",
+        "contents": { "nodes": [
+            {
+              "id": "065c2f4d-96bb-4d5f-b3b1-2c46886f9978",
+              "name": "Break (1)",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "a2c593a9-5872-4dac-a3a0-8abcf6d3c3f8",
+                  "name": "Input",
+                  "type_name": "nos.track.Track",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "def": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "abbaf38d-ba75-4267-9745-75f1a5489518",
+                  "name": "location",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "79aaf6f5-dcf4-4319-ba54-833b8146fc5d",
+                  "name": "rotation",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "5c09eaa2-7ef7-42b0-8b76-f6bda3c425e4",
+                  "name": "fov",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 74.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "4172afc6-c51e-43f2-bc42-e08f3e0ecc2b",
+                  "name": "zoom",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "3494f976-ac03-453d-ac68-5c2c54212a5a",
+                  "name": "focus",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "0ba4419b-8ec6-4f85-8758-9b57d7327806",
+                  "name": "render_ratio",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ba9d7ad4-0e35-4fdc-87b2-8d1dfeaa25b9",
+                  "name": "sensor_size",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 9.59, "y": 5.394 },
+                  "def": { "x": 0.0, "y": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "296ad361-3a04-4379-aae7-3ecf829f3944",
+                  "name": "pixel_aspect_ratio",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "049ef970-287e-4deb-8932-6c38d4a036e3",
+                  "name": "nodal_offset",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "15a26286-b94d-4463-b48f-cfeb5b861e1f",
+                  "name": "focus_distance",
+                  "type_name": "float",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "e48dd2d4-54dc-4b73-9a7e-9ec59f0e495a",
+                  "name": "lens_distortion",
+                  "type_name": "nos.track.LensDistortion",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 },
+                  "def": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -74.339447, "y": 276.36264 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Break nos.track.Track",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "e44ccb72-7ab7-4013-ae6d-0f05ded039c4",
+              "name": "Make",
+              "class_name": "nos.reflect.MakeDynamic",
+              "pins": [
+                {
+                  "id": "7fe370d1-27f8-4a86-a724-1ad6e81108dd",
+                  "name": "Output",
+                  "type_name": "nos.track.Track",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "location": { "x": 1.797839, "y": 2.031795, "z": 1.719097 },
+                    "rotation": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                    "fov": 74.0,
+                    "zoom": 0.0,
+                    "focus": 0.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "nodal_offset": 0.0,
+                    "focus_distance": 0.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "def": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "94caef70-59a7-43fb-af87-04a175108b23",
+                  "name": "location",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.797839, "y": 2.031795, "z": 1.719097 },
+                  "def": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "5630bbaf-c2c3-4f4c-9f63-a4564895246b",
+                  "name": "rotation",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "7fd5c452-6235-43c7-8e42-d584e383f5b8",
+                  "name": "fov",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 74.0,
+                  "def": 74.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "42abc862-9ff2-4132-92f5-878f179aa7f6",
+                  "name": "zoom",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "98309aef-54a4-4f92-a72c-37ff7fae714a",
+                  "name": "focus",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "8e535536-efda-42af-a134-bf9061f6084b",
+                  "name": "render_ratio",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "def": 1.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "aa232c30-4cff-4661-818a-341a09885715",
+                  "name": "sensor_size",
+                  "type_name": "nos.fb.vec2",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 9.59, "y": 5.394 },
+                  "def": { "x": 9.59, "y": 5.394 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "00a1685b-e159-4d62-9976-7cf86f99136d",
+                  "name": "pixel_aspect_ratio",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 1.0,
+                  "def": 1.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "223d74b4-41ec-439f-8526-2399c0857dc2",
+                  "name": "nodal_offset",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "4c090d0e-07f2-4441-b8a4-6f7988d4feec",
+                  "name": "focus_distance",
+                  "type_name": "float",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": 0.0,
+                  "def": 0.0,
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "338d2a08-6fe0-4cc4-a345-03916ed8ff24",
+                  "name": "lens_distortion",
+                  "type_name": "nos.track.LensDistortion",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 },
+                  "def": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 327.660553, "y": 152.36264 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "template_parameters": [
+                { "name": "Type", "type_name": "string", "value": "nos.track.Track" }
+              ],
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "ef768cb1-5c61-4ad0-825c-46200d4b4865",
+              "name": "MultiplyByZ180",
+              "class_name": "nos.math.QuaternionMultiply",
+              "pins": [
+                {
+                  "id": "d6099291-af43-4207-a10e-04e00a2f4db0",
+                  "name": "A",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.051124280864, "y": -0.081418113625, "z": 0.842818976702, "w": -0.52954090606 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "41ff5dba-5c89-4a7b-afd5-cd477cc92845",
+                  "name": "B",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "description": "Constant 180-degree rotation about Z; see the comment box."
+                },
+                {
+                  "id": "d914d162-01e2-411e-9ea7-fe48df69fd89",
+                  "name": "Result",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -0.081418113625, "y": -0.051124280864, "z": -0.52954090606, "w": -0.842818976702 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -310.339447, "y": 40.36264 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 1, "minor": 11, "patch": 0 }
+            },
+            {
+              "id": "83184e80-15dd-4ace-87c3-00fcb0f6f1ce",
+              "name": "Z180Multiply",
+              "class_name": "nos.math.QuaternionMultiply",
+              "pins": [
+                {
+                  "id": "6e320bec-ee1b-4e1c-a8eb-3b797d57d2e4",
+                  "name": "A",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.0, "y": 0.0, "z": 1.0, "w": 0.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "description": "Constant 180-degree rotation about Z; see the comment box."
+                },
+                {
+                  "id": "fe67255f-4e7a-4e29-888f-cd8fa145e14e",
+                  "name": "B",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": -0.081418113625, "y": -0.051124280864, "z": -0.52954090606, "w": -0.842818976702 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "ffdef587-0897-4f6c-af59-26d07b70f6a4",
+                  "name": "Result",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.051124280864, "y": -0.081418113625, "z": -0.842818976702, "w": 0.52954090606 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -205.339447, "y": 40.36264 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 1, "minor": 11, "patch": 0 }
+            },
+            {
+              "id": "e4efd422-cac1-408c-a6cd-202fb465c8c0",
+              "name": "vec3d to vec3 (1)",
+              "class_name": "cast.vec3d-vec3",
+              "pins": [
+                {
+                  "id": "191eeb28-af51-4117-be2e-95f492d98b9f",
+                  "name": "vec3d",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "824d62ae-7fb3-4e04-94fb-919379882d44",
+                  "name": "vec3",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 123.660553, "y": 55.36264 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "230c5120-42e0-4ebf-bea0-10a7c5a78ab3",
+              "name": "Output",
+              "class_name": "nos.internal.GraphOutput",
+              "pins": [
+                {
+                  "id": "56e18572-0d68-400e-b6fd-1d4c12e51ae5",
+                  "name": "Input",
+                  "type_name": "nos.track.Track",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "location": { "x": 1.797839, "y": 2.031795, "z": 1.719097 },
+                    "rotation": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                    "fov": 74.0,
+                    "zoom": 0.0,
+                    "focus": 0.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "nodal_offset": 0.0,
+                    "focus_distance": 0.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "def": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "6315f140-ca41-4744-9ccd-c1327ec8f8fb",
+                  "name": "Output",
+                  "type_name": "nos.track.Track",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "location": { "x": 1.797839, "y": 2.031795, "z": 1.719097 },
+                    "rotation": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                    "fov": 74.0,
+                    "zoom": 0.0,
+                    "focus": 0.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "nodal_offset": 0.0,
+                    "focus_distance": 0.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "referred_by": [
+                    "1e206698-7549-4cbc-8f69-e1796a7828c0"
+                  ],
+                  "def": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "connection_conditions": "!array"
+                }
+              ],
+              "pos": { "x": 648.160522, "y": 117.122452 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "e255f826-8c61-4e81-864e-505c45166b3d",
+              "name": "vec3d to vec3",
+              "class_name": "cast.vec3d-vec3",
+              "pins": [
+                {
+                  "id": "052a9207-d336-49db-a48e-bb99e632caed",
+                  "name": "vec3d",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.797839413158, "y": 2.03179492706, "z": 1.719097147995 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "1c25ba7f-7138-431e-8e07-023f20183cce",
+                  "name": "vec3",
+                  "type_name": "nos.fb.vec3",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.797839, "y": 2.031795, "z": 1.719097 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "meta_data_map": [
+                    { "key": "Category", "value": "" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": 107.660553, "y": -19.63736 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "69a22b8f-3289-4cfc-96d7-0ab1c53ebdc0",
+              "name": "Input",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "73fee6c1-7957-4dee-8625-dbca4628b374",
+                  "name": "Output",
+                  "type_name": "nos.track.Track",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "def": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "66c23108-61e0-410f-879e-a8be578cbffa",
+                  "name": "Input",
+                  "type_name": "nos.track.Track",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "referred_by": [
+                    "fafae63e-ef87-4d1e-a3e9-2997515ae14a"
+                  ],
+                  "def": {
+                    "location": { "x": 600.0, "y": 50.0, "z": 100.0 },
+                    "rotation": { "x": 0.0, "y": 0.0, "z": 180.0 },
+                    "fov": 74.0,
+                    "render_ratio": 1.0,
+                    "sensor_size": { "x": 9.59, "y": 5.394 },
+                    "pixel_aspect_ratio": 1.0,
+                    "lens_distortion": { "k1k2": { "x": 0.0, "y": 0.0 }, "center_shift": { "x": 0.0, "y": 0.0 }, "distortion_scale": 1.0 }
+                  },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -647.0, "y": 134.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Track",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            },
+            {
+              "id": "bdd381df-1f4b-4cac-9cd7-be6ca1ac19a5",
+              "name": "Break",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "2f3e4085-584d-40e9-bc80-295ea5162b38",
+                  "name": "Input",
+                  "type_name": "nos.track.TransformQ",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "position": { "x": 1.797839413158, "y": 2.03179492706, "z": 1.719097147995 }, "rotation": { "x": 0.051124280864, "y": -0.081418113625, "z": 0.842818976702, "w": -0.52954090606 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "scale": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "b2ca7d18-24ac-4f94-8fd2-c60cfc30a93e",
+                  "name": "position",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.797839413158, "y": 2.03179492706, "z": 1.719097147995 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "d4d4246c-0e06-4766-8683-0a84b390597e",
+                  "name": "rotation",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.051124280864, "y": -0.081418113625, "z": 0.842818976702, "w": -0.52954090606 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "bd377b96-289c-4aae-8d62-128caa7dead2",
+                  "name": "scale",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 1.0, "y": 1.0, "z": 1.0 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -388.339447, "y": -3.63736 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Break nos.graphics.TransformQ",
+              "plugin_version": { "major": 1, "minor": 7, "patch": 16 }
+            },
+            {
+              "id": "e8167069-39f5-4359-8a78-990aaf2a31a4",
+              "name": "QuaternionToEuler",
+              "class_name": "nos.math.QuaternionToEuler",
+              "pins": [
+                {
+                  "id": "68180c65-fc05-4c01-afbc-10257847873f",
+                  "name": "Quaternion",
+                  "type_name": "nos.fb.vec4d",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 0.051124280864, "y": -0.081418113625, "z": -0.842818976702, "w": 0.52954090606 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "150ab3d2-f0f2-41b6-95fd-f5a0f8512df0",
+                  "name": "Order",
+                  "type_name": "nos.math.EulerOrder",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": "ZYX",
+                  "def": "ZYX",
+                  "contents_type": "JobPin",
+                  "contents": { },
+                  "description": "Euler intrinsic rotation order extracted into the (rot.x, rot.y, rot.z) output components."
+                },
+                {
+                  "id": "23e9fc73-a2c5-4278-916d-2c7a2941207f",
+                  "name": "Euler",
+                  "type_name": "nos.fb.vec3d",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "x": 11.0337, "y": -0.0029, "z": -115.7182 },
+                  "def": { "x": 0.0, "y": 0.0, "z": 0.0 },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -97.339447, "y": 40.36264 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "description": "Converts a unit quaternion (x, y, z, w) to Euler angles (degrees). The Order pin selects the intrinsic rotation order extracted (e.g. ZYX yields rot.z = first rotation about Z, rot.y about Y, rot.x about X). Inverse of EulerToQuaternion when the same Order is used on both ends.",
+              "plugin_version": { "major": 1, "minor": 11, "patch": 0 }
+            },
+            {
+              "id": "0fc9a01a-1402-4482-a82b-37a2766d0e51",
+              "name": "Input (1)",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "f1eb6cf4-bbd1-4795-b678-9b66d49838b7",
+                  "name": "Output",
+                  "type_name": "nos.track.TransformQ",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {
+                  },
+                  "data": { "position": { "x": 1.797839413158, "y": 2.03179492706, "z": 1.719097147995 }, "rotation": { "x": 0.051124280864, "y": -0.081418113625, "z": 0.842818976702, "w": -0.52954090606 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "scale": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+                  "contents_type": "JobPin",
+                  "contents": { }
+                },
+                {
+                  "id": "7fca9817-ae9e-44f6-80a0-b89c94a65e6c",
+                  "name": "Input",
+                  "type_name": "nos.track.TransformQ",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                  },
+                  "data": { "position": { "x": 1.797839413158, "y": 2.03179492706, "z": 1.719097147995 }, "rotation": { "x": 0.051124280864, "y": -0.081418113625, "z": 0.842818976702, "w": -0.52954090606 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+                  "referred_by": [
+                    "0efb4000-a3b6-49c0-9f1d-f9a7d0ace9c5"
+                  ],
+                  "def": { "position": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 0.0 }, "scale": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+                  "meta_data_map": [
+                    { "key": "PinHidden", "value": "true" }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": { }
+                }
+              ],
+              "pos": { "x": -660.0, "y": 79.0 },
+              "contents_type": "Job",
+              "contents": { "type": "" },
+              "function_category": "Default Node",
+              "display_name": "Transform",
+              "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+            }
+          ], "comments": [
+            {
+              "id": "a0f3b3eb-7b9a-43b9-b22c-889e54215cb5",
+              "name": "Comment",
+              "hint": "Hint",
+              "content": "Embed Transform to Track.\nTrack.rotation is Unreal-convention (roll, pitch, yaw): R = Rz(yaw) * Ry(-pitch) * Rx(-roll), i.e. a plain ZYX extraction with the X and Y angles negated. No Euler order alone can produce those sign flips, but conjugating the quaternion by a 180-degree rotation about Z (qZ * q * qZ with qZ = (0, 0, 1, 0)) negates exactly the X and Y angles of the ZYX extraction, so QuaternionToEuler(ZYX) then lands directly in Track's convention.",
+              "pos": { "x": -45.339447, "y": 145.36264 },
+              "size": { "x": 987.0, "y": 492.0 },
+              "bg_color": { "x": 0.9, "y": 0.9, "z": 0.9, "w": 0.3 }
+            }
+          ], "connections": [
+            { "from": "1c25ba7f-7138-431e-8e07-023f20183cce", "to": "94caef70-59a7-43fb-af87-04a175108b23", "id": "9d5192c3-cda9-4070-8c6d-5e7cb6328642" },
+            { "from": "0ba4419b-8ec6-4f85-8758-9b57d7327806", "to": "8e535536-efda-42af-a134-bf9061f6084b", "id": "411559f6-b77a-43d8-bb6b-6651a7e78e89" },
+            { "from": "15a26286-b94d-4463-b48f-cfeb5b861e1f", "to": "4c090d0e-07f2-4441-b8a4-6f7988d4feec", "id": "849f3d7b-4a65-4ff4-a2d3-27c566f598b7" },
+            { "from": "824d62ae-7fb3-4e04-94fb-919379882d44", "to": "5630bbaf-c2c3-4f4c-9f63-a4564895246b", "id": "19b10a49-e35d-4e40-9ccd-5259ac8aceb3" },
+            { "from": "23e9fc73-a2c5-4278-916d-2c7a2941207f", "to": "191eeb28-af51-4117-be2e-95f492d98b9f", "id": "e33fc853-e29c-4766-a362-baae4e8d1b7b" },
+            { "from": "3494f976-ac03-453d-ac68-5c2c54212a5a", "to": "98309aef-54a4-4f92-a72c-37ff7fae714a", "id": "b9ed7e73-aeb1-493b-954b-ba6ea682ab26" },
+            { "from": "ba9d7ad4-0e35-4fdc-87b2-8d1dfeaa25b9", "to": "aa232c30-4cff-4661-818a-341a09885715", "id": "257ab3f2-bd42-4b55-a4be-9cf0f4c7a570" },
+            { "from": "5c09eaa2-7ef7-42b0-8b76-f6bda3c425e4", "to": "7fd5c452-6235-43c7-8e42-d584e383f5b8", "id": "44914b69-b404-45af-8525-4d1b25bbfb7a" },
+            { "from": "4172afc6-c51e-43f2-bc42-e08f3e0ecc2b", "to": "42abc862-9ff2-4132-92f5-878f179aa7f6", "id": "bc808b23-93bc-4bbb-9fca-22dce165f18b" },
+            { "from": "7fe370d1-27f8-4a86-a724-1ad6e81108dd", "to": "56e18572-0d68-400e-b6fd-1d4c12e51ae5", "id": "e99303d3-b859-421d-94e8-84b9582a184a" },
+            { "from": "296ad361-3a04-4379-aae7-3ecf829f3944", "to": "00a1685b-e159-4d62-9976-7cf86f99136d", "id": "772378b5-3aa6-4835-b2f1-8550ed75a162" },
+            { "from": "049ef970-287e-4deb-8932-6c38d4a036e3", "to": "223d74b4-41ec-439f-8526-2399c0857dc2", "id": "de05d70e-a92b-4a9b-bbd3-b528d110b6e6" },
+            { "from": "e48dd2d4-54dc-4b73-9a7e-9ec59f0e495a", "to": "338d2a08-6fe0-4cc4-a345-03916ed8ff24", "id": "10ba87e1-0744-42f7-8695-23c20555dc3a" },
+            { "from": "b2ca7d18-24ac-4f94-8fd2-c60cfc30a93e", "to": "052a9207-d336-49db-a48e-bb99e632caed", "id": "eae6b39a-226a-4d13-9740-24eee00cef0d" },
+            { "from": "d4d4246c-0e06-4766-8683-0a84b390597e", "to": "d6099291-af43-4207-a10e-04e00a2f4db0", "id": "60d7fc83-03fd-4487-8942-97a01e8b6986" },
+            { "from": "d914d162-01e2-411e-9ea7-fe48df69fd89", "to": "fe67255f-4e7a-4e29-888f-cd8fa145e14e", "id": "f4ca285e-efd4-42f4-ab5a-d9da5f68e46d" },
+            { "from": "ffdef587-0897-4f6c-af59-26d07b70f6a4", "to": "68180c65-fc05-4c01-afbc-10257847873f", "id": "0b06576a-c67d-4083-bf8a-f021b1e41ba0" },
+            { "from": "73fee6c1-7957-4dee-8625-dbca4628b374", "to": "a2c593a9-5872-4dac-a3a0-8abcf6d3c3f8", "id": "24bc5915-d94a-4174-8d23-a539c1f059c0" },
+            { "from": "f1eb6cf4-bbd1-4795-b678-9b66d49838b7", "to": "2f3e4085-584d-40e9-bc80-295ea5162b38", "id": "5c248d43-481d-418f-b9c5-79f56b416285" }
+          ] },
+        "function_category": "Default Node",
+        "plugin_version": { "major": 0, "minor": 0, "patch": 0 }
+      }
+    }
+  ] }

--- a/Plugins/nosTrack/Source/ConvertTrackFrame.cpp
+++ b/Plugins/nosTrack/Source/ConvertTrackFrame.cpp
@@ -1,0 +1,54 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosTrack/Track_generated.h>
+#include <glm/glm.hpp>
+
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::track
+{
+
+void RegisterConvertTrackFrame(nosNodeFunctions* funcs)
+{
+	funcs->ClassName = NOS_NAME("ConvertTrackFrame");
+	funcs->ExecuteNode = [](void*, nosNodeExecuteParams* params) {
+		nos::NodeExecuteParams pins(params);
+
+		nos::track::TTrack out = pins.GetPinValue<nos::track::TTrack>(NOS_NAME("In"));
+		auto source = *pins.GetPinValue<nos::track::Frame>(NOS_NAME("Source"));
+		auto target = *pins.GetPinValue<nos::track::Frame>(NOS_NAME("Target"));
+
+		if (!nos::track::CoordinateFrameValid(source) || !nos::track::CoordinateFrameValid(target))
+		{
+			nosEngine.LogE("ConvertTrackFrame: Source/Target frame invalid (forward and up must be on different axes)");
+			nosEngine.SetPinValue(pins[NOS_NAME("Out")].Id, nos::Buffer::From(out));
+			return NOS_RESULT_SUCCESS;
+		}
+
+		const nos::track::FrameConvert conv = nos::track::MakeFrameConvert(source, target);
+
+		// Location: basis change, then unit conversion derived from the two systems'
+		// meters_per_unit. Other Track fields (fov, focus, sensor_size,
+		// lens_distortion, ...) are unaffected.
+		const auto inLoc = out.location;
+		glm::dvec3 outLoc = nos::track::ConvertPosition(conv, glm::dvec3(inLoc.x(), inLoc.y(), inLoc.z()));
+		out.location.mutate_x(static_cast<float>(outLoc.x));
+		out.location.mutate_y(static_cast<float>(outLoc.y));
+		out.location.mutate_z(static_cast<float>(outLoc.z));
+
+		// Rotation: decode source Euler -> matrix, conjugate by M, re-encode as
+		// target Euler.
+		const auto inRot = out.rotation;
+		glm::dmat3 R_src = nos::track::EulerToMat(source.euler(), glm::dvec3(inRot.x(), inRot.y(), inRot.z()));
+		glm::dvec3 outRotDeg = nos::track::MatToEuler(target.euler(), nos::track::ConvertRotation(conv, R_src));
+		out.rotation.mutate_x(static_cast<float>(outRotDeg.x));
+		out.rotation.mutate_y(static_cast<float>(outRotDeg.y));
+		out.rotation.mutate_z(static_cast<float>(outRotDeg.z));
+
+		nosEngine.SetPinValue(pins[NOS_NAME("Out")].Id, nos::Buffer::From(out));
+		return NOS_RESULT_SUCCESS;
+	};
+}
+
+}  // namespace nos::track

--- a/Plugins/nosTrack/Source/ConvertTransform.cpp
+++ b/Plugins/nosTrack/Source/ConvertTransform.cpp
@@ -1,0 +1,58 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <Builtins_generated.h>
+#include <glm/glm.hpp>
+
+#include <cmath>
+
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::track
+{
+
+void RegisterConvertTransform(nosNodeFunctions* funcs)
+{
+	funcs->ClassName = NOS_NAME("ConvertTransform");
+	funcs->ExecuteNode = [](void*, nosNodeExecuteParams* params) {
+		nos::NodeExecuteParams pins(params);
+
+		// nos.fb.Transform is a struct, so the pin data is the raw struct bytes.
+		auto* in = pins.GetPinValue<nos::fb::Transform>(NOS_NAME("In"));
+		auto source = *pins.GetPinValue<nos::track::Frame>(NOS_NAME("SourceFrame"));
+		auto target = *pins.GetPinValue<nos::track::Frame>(NOS_NAME("TargetFrame"));
+
+		if (!nos::track::CoordinateFrameValid(source) || !nos::track::CoordinateFrameValid(target))
+		{
+			nosEngine.LogE("ConvertTransform: Source/Target frame invalid (forward and up must be on different axes)");
+			nosEngine.SetPinValue(pins[NOS_NAME("Out")].Id, nos::Buffer::From(*in));
+			return NOS_RESULT_SUCCESS;
+		}
+
+		const nos::track::FrameConvert conv = nos::track::MakeFrameConvert(source, target);
+
+		// Position: basis change, then unit conversion derived from the two systems.
+		const auto& p = in->position();
+		glm::dvec3 outPos = nos::track::ConvertPosition(conv, glm::dvec3(p.x(), p.y(), p.z()));
+
+		// Rotation: decode source Euler -> matrix, conjugate by M, re-encode as
+		// target Euler. The encodings carry the per-frame Euler order/signs.
+		const auto& r = in->rotation();
+		glm::dmat3 R_src = nos::track::EulerToMat(source.euler(), glm::dvec3(r.x(), r.y(), r.z()));
+		glm::dvec3 outRot = nos::track::MatToEuler(target.euler(), nos::track::ConvertRotation(conv, R_src));
+
+		// Scale: M is a signed axis permutation, so the per-axis factors just reorder.
+		const auto& s = in->scale();
+		glm::dvec3 outScale = nos::track::ConvertScale(conv, glm::dvec3(s.x(), s.y(), s.z()));
+
+		nos::fb::Transform out(
+			nos::fb::vec3d(outPos.x, outPos.y, outPos.z),
+			nos::fb::vec3d(outRot.x, outRot.y, outRot.z),
+			nos::fb::vec3d(outScale.x, outScale.y, outScale.z));
+
+		nosEngine.SetPinValue(pins[NOS_NAME("Out")].Id, nos::Buffer::From(out));
+		return NOS_RESULT_SUCCESS;
+	};
+}
+
+}  // namespace nos::track

--- a/Plugins/nosTrack/Source/PlaybackTrackCOLMAP.cpp
+++ b/Plugins/nosTrack/Source/PlaybackTrackCOLMAP.cpp
@@ -1,0 +1,652 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include "nosTrack/Track_generated.h"
+#include <nosTrack/PlaybackMode_generated.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <fstream>
+#include <filesystem>
+#include <vector>
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <unordered_map>
+
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::track
+{
+
+NOS_REGISTER_NAME_SPACED(Playback_InputDirectory, "InputDirectory");
+NOS_REGISTER_NAME_SPACED(Playback_TargetFrame, "TargetFrame");
+NOS_REGISTER_NAME_SPACED(Playback_Mode, "Mode");
+NOS_REGISTER_NAME_SPACED(Playback_InFrameIndex, "InFrameIndex");
+NOS_REGISTER_NAME_SPACED(Playback_InTimecode, "InTimecode");
+NOS_REGISTER_NAME_SPACED(Playback_InFrameNumber, "InFrameNumber");
+NOS_REGISTER_NAME_SPACED(Playback_OutFrameIndex, "OutFrameIndex");
+NOS_REGISTER_NAME_SPACED(Playback_FrameCount, "FrameCount");
+
+NOS_REGISTER_NAME(PlaybackTrackCOLMAP_OpenFolder);
+
+struct COLMAPCamera
+{
+	uint32_t Id = 0;
+	std::string Model;
+	uint32_t Width = 0;
+	uint32_t Height = 0;
+	float Fx = 0, Fy = 0, Cx = 0, Cy = 0;
+	float K1 = 0, K2 = 0, P1 = 0, P2 = 0;
+};
+
+struct COLMAPImage
+{
+	uint32_t Id = 0;
+	glm::quat Q{1, 0, 0, 0};  // R_w2c in COLMAP camera frame.
+	glm::vec3 T{0};           // t = -R_w2c * camera_world_position (COLMAP world frame).
+	uint32_t CameraId = 0;
+};
+
+struct TimecodeEntry
+{
+	std::string Timecode;
+	uint32_t FrameNumber = 0;
+};
+
+struct ExtrasEntry
+{
+	bool Present = false;
+	float Zoom = 0;
+	float Focus = 0;
+	float FocusDistance = 0;
+	float RenderRatio = 0;
+	float NodalOffset = 0;
+	float DistortionScale = 0;
+	float SensorWmm = 0;
+	float SensorHmm = 0;
+	float RotX = 0;
+	float RotY = 0;
+	float RotZ = 0;
+};
+
+template <typename TEnum, size_t N>
+static bool EnumFromName(TEnum const (&values)[N], char const* const* names, std::string const& name, TEnum& out)
+{
+	for (size_t i = 0; i < N; ++i)
+		if (name == names[i])
+		{
+			out = values[i];
+			return true;
+		}
+	return false;
+}
+
+// Inverse of the "# SourceFrame: up=... forward=... handedness=... euler_order=...
+// euler_sign=x,y,z" header written by RecordTrackCOLMAP::WriteExtrasTxt. Returns
+// nullopt when any field is missing or unrecognized (e.g. a hand-edited sidecar).
+static std::optional<nos::track::Frame> ParseSourceFrameComment(std::string const& line)
+{
+	auto value = [&](char const* key) -> std::string {
+		auto pos = line.find(key);
+		if (pos == std::string::npos)
+			return {};
+		pos += std::strlen(key);
+		return line.substr(pos, line.find(' ', pos) - pos);
+	};
+	nos::track::SignedAxis up{}, fwd{};
+	nos::track::Handedness hand{};
+	nos::track::EulerOrder order{};
+	if (!EnumFromName(nos::track::EnumValuesSignedAxis(), nos::track::EnumNamesSignedAxis(), value("up="), up) ||
+		!EnumFromName(nos::track::EnumValuesSignedAxis(), nos::track::EnumNamesSignedAxis(), value("forward="), fwd) ||
+		!EnumFromName(nos::track::EnumValuesHandedness(), nos::track::EnumNamesHandedness(), value("handedness="), hand) ||
+		!EnumFromName(nos::track::EnumValuesEulerOrder(), nos::track::EnumNamesEulerOrder(), value("euler_order="), order))
+		return std::nullopt;
+
+	// euler_sign=x,y,z, each +1/-1. Missing or garbled -> reject the whole header.
+	int sx = 0, sy = 0, sz = 0;
+	std::string signs = value("euler_sign=");
+	std::replace(signs.begin(), signs.end(), ',', ' ');
+	std::istringstream ss(signs);
+	if (!(ss >> sx >> sy >> sz))
+		return std::nullopt;
+
+	// meters_per_unit is irrelevant to rotation, which is all this frame is used for.
+	return nos::track::Frame(up, fwd, hand,
+		nos::track::EulerEncoding(order, (int8_t)sx, (int8_t)sy, (int8_t)sz), 1.0);
+}
+
+// True when Euler angles authored in `a` decode to the same rotation as in `b`
+// (same basis and same nested Euler encoding; units don't enter into rotation).
+static bool SameRotationConvention(nos::track::Frame const& a, nos::track::Frame const& b)
+{
+	return a.up() == b.up() && a.forward() == b.forward() && a.handedness() == b.handedness() &&
+		   a.euler().order() == b.euler().order() &&
+		   a.euler().sign_x() == b.euler().sign_x() &&
+		   a.euler().sign_y() == b.euler().sign_y() &&
+		   a.euler().sign_z() == b.euler().sign_z();
+}
+
+struct PlaybackTrackCOLMAPContext : NodeContext
+{
+	std::string InputDir;
+	nos::track::Frame TargetFrame = nos::track::UNREAL_SYSTEM;
+	PlaybackTrackMode Mode = PlaybackTrackMode::FrameIndex;
+	uint32_t FrameIndex = 0;
+	std::string InTimecode;
+	uint32_t InFrameNumber = 0;
+	std::string LastError;
+	std::vector<nos::track::TTrack> Frames;
+	std::vector<TimecodeEntry> Timecodes; // empty or same size as Frames
+	std::unordered_map<std::string, uint32_t> TimecodeToIndex;
+	std::unordered_map<uint32_t, uint32_t> FrameNumberToIndex;
+	uint32_t CurrentFrame = 0;
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		if (node->pins())
+		{
+			for (auto* pin : *node->pins())
+			{
+				auto name = nos::Name(pin->name()->c_str());
+				if (flatbuffers::IsFieldPresent(pin, fb::Pin::VT_DATA))
+				{
+					nosBuffer value = {.Data = (void*)pin->data()->data(), .Size = pin->data()->size()};
+					OnPinValueChanged(name, *pin->id(), value);
+				}
+			}
+		}
+		ApplyModeOrphanStates();
+		UpdateStatus();
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinValueChanged(nos::Name pinName, uuid const& pinId, nosBuffer val) override
+	{
+		if (pinName == NSN_Playback_InputDirectory)
+		{
+			InputDir = static_cast<const char*>(val.Data);
+			LastError.clear();
+			if (!InputDir.empty())
+				LoadFromDirectory();
+			else
+				UpdateStatus();
+		}
+		else if (pinName == NSN_Playback_TargetFrame)
+		{
+			TargetFrame = *(nos::track::Frame*)val.Data;
+			if (!InputDir.empty())
+				LoadFromDirectory();
+		}
+		else if (pinName == NSN_Playback_Mode)
+		{
+			Mode = *(PlaybackTrackMode*)val.Data;
+			ApplyModeOrphanStates();
+		}
+		else if (pinName == NSN_Playback_InFrameIndex)
+			FrameIndex = *(uint32_t*)val.Data;
+		else if (pinName == NSN_Playback_InTimecode)
+			InTimecode = static_cast<const char*>(val.Data);
+		else if (pinName == NSN_Playback_InFrameNumber)
+			InFrameNumber = *(uint32_t*)val.Data;
+	}
+
+	void ApplyModeOrphanStates()
+	{
+		auto state = [](bool active) {
+			return active ? fb::PinOrphanStateType::ACTIVE : fb::PinOrphanStateType::PASSIVE;
+		};
+		const bool useIdx = Mode == PlaybackTrackMode::FrameIndex;
+		const bool useTC  = Mode == PlaybackTrackMode::Timecode;
+		const bool useFN  = Mode == PlaybackTrackMode::FrameNumber;
+		SetPinOrphanState(NSN_Playback_InFrameIndex,  state(useIdx));
+		SetPinOrphanState(NSN_Playback_InTimecode,    state(useTC));
+		SetPinOrphanState(NSN_Playback_InFrameNumber, state(useFN));
+	}
+
+	void UpdateFrameCountPin()
+	{
+		uint32_t count = (uint32_t)Frames.size();
+		SetPinValue(NSN_Playback_FrameCount, nosBuffer{.Data = &count, .Size = sizeof(count)});
+	}
+
+	void UpdateFrameIndexPin()
+	{
+		SetPinValue(NSN_Playback_OutFrameIndex, nosBuffer{.Data = &CurrentFrame, .Size = sizeof(CurrentFrame)});
+	}
+
+	void UpdateStatus()
+	{
+		if (!LastError.empty())
+			SetNodeStatusMessage(LastError, fb::NodeStatusMessageType::FAILURE);
+		else if (InputDir.empty())
+			SetNodeStatusMessage("Set input directory", fb::NodeStatusMessageType::WARNING);
+		else if (Frames.empty())
+			SetNodeStatusMessage("No data loaded", fb::NodeStatusMessageType::WARNING);
+		else
+			SetNodeStatusMessage("Loaded (" + std::to_string(Frames.size()) + " frames)", fb::NodeStatusMessageType::INFO);
+	}
+
+	// --- Parsing ---
+
+	bool LoadFromDirectory()
+	{
+		if (InputDir.empty())
+		{
+			LastError = "Set input directory";
+			UpdateStatus();
+			return false;
+		}
+
+		std::filesystem::path dir = nos::Utf8ToPath(InputDir);
+		auto camerasPath = dir / "cameras.txt";
+		auto imagesPath = dir / "images.txt";
+
+		if (!std::filesystem::exists(camerasPath))
+		{
+			LastError = "cameras.txt not found";
+			UpdateStatus();
+			return false;
+		}
+		if (!std::filesystem::exists(imagesPath))
+		{
+			LastError = "images.txt not found";
+			UpdateStatus();
+			return false;
+		}
+
+		std::unordered_map<uint32_t, COLMAPCamera> cameras;
+		if (!ParseCamerasTxt(camerasPath, cameras))
+			return false;
+
+		std::vector<COLMAPImage> images;
+		if (!ParseImagesTxt(imagesPath, images))
+			return false;
+
+		if (images.empty())
+		{
+			LastError = "No images found in images.txt";
+			UpdateStatus();
+			return false;
+		}
+
+		Frames.clear();
+		Frames.reserve(images.size());
+		Timecodes.clear();
+
+		auto timecodesPath = dir / "timecodes.txt";
+		if (std::filesystem::exists(timecodesPath))
+			ParseTimecodesTxt(timecodesPath, images.size());
+
+		std::vector<ExtrasEntry> extras;
+		std::optional<nos::track::Frame> extrasFrame;
+		auto extrasPath = dir / "extras.txt";
+		if (std::filesystem::exists(extrasPath))
+			ParseExtrasTxt(extrasPath, images.size(), extras, extrasFrame);
+
+		// Inverse of RecordTrackCOLMAP::WriteImagesTxt:
+		//   images.txt holds R_w2c in COLMAP frame, t = -R_w2c * pos_colmap.
+		//   pos_colmap = -R_c2w_colmap * t   (R_c2w_colmap = R_w2c^T)
+		//   pos_target = M^-1 * pos_colmap
+		//   R_c2w_target = M^-1 * R_c2w_colmap * M
+		//   Track.rotation = MatToEuler(TargetFrame, R_c2w_target)
+		const glm::dmat3 Minv = nos::track::BasisChangeFromColmap(TargetFrame);
+		const glm::dmat3 M = glm::inverse(Minv);
+		// Scale COLMAP units (meters) back into the target system's units.
+		const double unitFactor = nos::track::UnitFactor(nos::track::COLMAP_SYSTEM, TargetFrame);
+
+		// Extras Euler is authored in the recording SourceFrame (recorded in the
+		// sidecar header). Re-express it in TargetFrame when the conventions
+		// differ; a sidecar without a parseable header is assumed to already
+		// match TargetFrame (pre-header recordings).
+		const bool convertExtrasRotation = extrasFrame && !SameRotationConvention(*extrasFrame, TargetFrame);
+		glm::dmat3 extrasC(1.0);
+		if (convertExtrasRotation)
+			extrasC = nos::track::BasisMatrix(TargetFrame) * glm::inverse(nos::track::BasisMatrix(*extrasFrame));
+
+		for (size_t i = 0; i < images.size(); ++i)
+		{
+			auto& img = images[i];
+			nos::track::TTrack trackData{};
+			auto camIt = cameras.find(img.CameraId);
+			const ExtrasEntry* ex = (i < extras.size() && extras[i].Present) ? &extras[i] : nullptr;
+
+			glm::dmat3 R_w2c = glm::dmat3(glm::mat3_cast(img.Q));
+			glm::dmat3 R_c2w_colmap = glm::transpose(R_w2c);
+			glm::dvec3 pos_colmap = -R_c2w_colmap * glm::dvec3(img.T);
+
+			glm::dvec3 pos_target = Minv * pos_colmap * unitFactor;
+			glm::vec3 locF((float)pos_target.x, (float)pos_target.y, (float)pos_target.z);
+			trackData.location = reinterpret_cast<nos::fb::vec3&>(locF);
+
+			// Rotation: prefer the original Euler from extras (avoids quaternion-
+			// to-Euler ambiguity near gimbal lock), converted into TargetFrame if
+			// it was recorded in a different one; fall back to extracting from
+			// the COLMAP rotation matrix when no extras sidecar exists.
+			if (ex)
+			{
+				glm::vec3 euler(ex->RotX, ex->RotY, ex->RotZ);
+				if (convertExtrasRotation)
+				{
+					glm::dmat3 R_src = nos::track::EulerToMat(extrasFrame->euler(), glm::dvec3(euler));
+					euler = glm::vec3(nos::track::MatToEuler(TargetFrame.euler(), extrasC * R_src * glm::transpose(extrasC)));
+				}
+				trackData.rotation = reinterpret_cast<nos::fb::vec3&>(euler);
+			}
+			else
+			{
+				glm::dmat3 R_c2w_target = Minv * R_c2w_colmap * M;
+				glm::dvec3 eulerD = nos::track::MatToEuler(TargetFrame.euler(), R_c2w_target);
+				glm::vec3 eulerF((float)eulerD.x, (float)eulerD.y, (float)eulerD.z);
+				trackData.rotation = reinterpret_cast<nos::fb::vec3&>(eulerF);
+			}
+
+			if (camIt != cameras.end())
+			{
+				auto& cam = camIt->second;
+				if (cam.Fx > 0)
+					trackData.fov = glm::degrees(2.0f * std::atan(cam.Width * 0.5f / cam.Fx));
+				if (cam.Fx > 0 && cam.Fy > 0)
+					trackData.pixel_aspect_ratio = cam.Fx / cam.Fy;
+				trackData.lens_distortion.mutable_k1k2() = nos::fb::vec2(cam.K1, cam.K2);
+
+				// sensor_size: COLMAP only stores pixel dims, but Track expects mm.
+				// Use the extras value when present; otherwise fall back to pixels
+				// (matches pre-extras behaviour).
+				glm::vec2 sensorMm(0);
+				if (ex && ex->SensorWmm > 0 && ex->SensorHmm > 0)
+				{
+					sensorMm = {ex->SensorWmm, ex->SensorHmm};
+					trackData.sensor_size = nos::fb::vec2(sensorMm.x, sensorMm.y);
+				}
+				else
+				{
+					trackData.sensor_size = nos::fb::vec2(cam.Width, cam.Height);
+				}
+
+				// center_shift: invert the (cx, cy) encoding written by record.
+				// Needs sensor_size in mm to be meaningful, so only reconstructed
+				// when extras provided it.
+				if (sensorMm.x > 0 && cam.Width > 0 && sensorMm.y > 0 && cam.Height > 0)
+				{
+					glm::vec2 shift{
+						(cam.Cx - cam.Width * 0.5f) * sensorMm.x / cam.Width,
+						(cam.Cy - cam.Height * 0.5f) * sensorMm.y / cam.Height};
+					trackData.lens_distortion.mutable_center_shift() = reinterpret_cast<nos::fb::vec2&>(shift);
+				}
+			}
+
+			if (ex)
+			{
+				trackData.zoom = ex->Zoom;
+				trackData.focus = ex->Focus;
+				trackData.focus_distance = ex->FocusDistance;
+				trackData.render_ratio = ex->RenderRatio;
+				trackData.nodal_offset = ex->NodalOffset;
+				trackData.lens_distortion.mutate_distortion_scale(ex->DistortionScale);
+			}
+
+			Frames.push_back(std::move(trackData));
+		}
+
+		CurrentFrame = 0;
+		LastError.clear();
+		UpdateFrameCountPin();
+		UpdateFrameIndexPin();
+		UpdateStatus();
+		nosEngine.LogI("PlaybackTrackCOLMAP: Loaded %zu frames from %s", Frames.size(), InputDir.c_str());
+		return true;
+	}
+
+	bool ParseCamerasTxt(const std::filesystem::path& path, std::unordered_map<uint32_t, COLMAPCamera>& cameras)
+	{
+		std::ifstream file(path);
+		if (!file.is_open())
+		{
+			LastError = "Cannot open cameras.txt";
+			UpdateStatus();
+			return false;
+		}
+
+		std::string line;
+		while (std::getline(file, line))
+		{
+			if (line.empty() || line[0] == '#')
+				continue;
+			std::istringstream ss(line);
+			COLMAPCamera cam;
+			ss >> cam.Id >> cam.Model >> cam.Width >> cam.Height;
+			if (cam.Model == "OPENCV")
+				ss >> cam.Fx >> cam.Fy >> cam.Cx >> cam.Cy >> cam.K1 >> cam.K2 >> cam.P1 >> cam.P2;
+			else if (cam.Model == "PINHOLE")
+				ss >> cam.Fx >> cam.Fy >> cam.Cx >> cam.Cy;
+			else if (cam.Model == "SIMPLE_PINHOLE")
+			{
+				float f;
+				ss >> f >> cam.Cx >> cam.Cy;
+				cam.Fx = cam.Fy = f;
+			}
+			else if (cam.Model == "SIMPLE_RADIAL")
+			{
+				float f;
+				ss >> f >> cam.Cx >> cam.Cy >> cam.K1;
+				cam.Fx = cam.Fy = f;
+			}
+			else if (cam.Model == "RADIAL")
+			{
+				float f;
+				ss >> f >> cam.Cx >> cam.Cy >> cam.K1 >> cam.K2;
+				cam.Fx = cam.Fy = f;
+			}
+			else
+			{
+				nosEngine.LogW("PlaybackTrackCOLMAP: Unsupported camera model '%s', treating as PINHOLE", cam.Model.c_str());
+				ss >> cam.Fx >> cam.Fy >> cam.Cx >> cam.Cy;
+			}
+			cameras[cam.Id] = cam;
+		}
+		return true;
+	}
+
+	bool ParseImagesTxt(const std::filesystem::path& path, std::vector<COLMAPImage>& images)
+	{
+		std::ifstream file(path);
+		if (!file.is_open())
+		{
+			LastError = "Cannot open images.txt";
+			UpdateStatus();
+			return false;
+		}
+
+		std::string line;
+		while (std::getline(file, line))
+		{
+			if (line.empty() || line[0] == '#')
+				continue;
+			std::istringstream ss(line);
+			COLMAPImage img;
+			float qw, qx, qy, qz;
+			std::string name;
+			ss >> img.Id >> qw >> qx >> qy >> qz
+			   >> img.T.x >> img.T.y >> img.T.z
+			   >> img.CameraId >> name;
+			img.Q = glm::quat(qw, qx, qy, qz);
+			images.push_back(img);
+			// Skip POINTS2D line
+			std::getline(file, line);
+		}
+
+		std::sort(images.begin(), images.end(), [](auto& a, auto& b) { return a.Id < b.Id; });
+		return true;
+	}
+
+	void ParseExtrasTxt(const std::filesystem::path& path, size_t expectedCount, std::vector<ExtrasEntry>& outExtras,
+						std::optional<nos::track::Frame>& outSourceFrame)
+	{
+		std::ifstream file(path);
+		if (!file.is_open())
+			return;
+		std::unordered_map<uint32_t, ExtrasEntry> byId;
+		std::string line;
+		while (std::getline(file, line))
+		{
+			if (line.rfind("# SourceFrame:", 0) == 0)
+			{
+				outSourceFrame = ParseSourceFrameComment(line);
+				continue;
+			}
+			if (line.empty() || line[0] == '#')
+				continue;
+			std::istringstream ss(line);
+			uint32_t id = 0;
+			ExtrasEntry e;
+			ss >> id >> e.Zoom >> e.Focus >> e.FocusDistance >> e.RenderRatio
+			   >> e.NodalOffset >> e.DistortionScale
+			   >> e.SensorWmm >> e.SensorHmm
+			   >> e.RotX >> e.RotY >> e.RotZ;
+			if (!ss.fail())
+			{
+				e.Present = true;
+				byId[id] = e;
+			}
+		}
+		outExtras.assign(expectedCount, ExtrasEntry{});
+		for (size_t i = 0; i < expectedCount; ++i)
+		{
+			auto it = byId.find(uint32_t(i + 1));
+			if (it != byId.end())
+				outExtras[i] = it->second;
+		}
+	}
+
+	void ParseTimecodesTxt(const std::filesystem::path& path, size_t expectedCount)
+	{
+		std::ifstream file(path);
+		if (!file.is_open())
+			return;
+		std::unordered_map<uint32_t, TimecodeEntry> byId;
+		std::string line;
+		while (std::getline(file, line))
+		{
+			if (line.empty() || line[0] == '#')
+				continue;
+			std::istringstream ss(line);
+			uint32_t id = 0;
+			TimecodeEntry e;
+			ss >> id >> e.Timecode >> e.FrameNumber;
+			if (e.Timecode == "-")
+				e.Timecode.clear();
+			byId[id] = std::move(e);
+		}
+		Timecodes.assign(expectedCount, TimecodeEntry{});
+		TimecodeToIndex.clear();
+		FrameNumberToIndex.clear();
+		for (size_t i = 0; i < expectedCount; ++i)
+		{
+			auto it = byId.find(uint32_t(i + 1));
+			if (it == byId.end())
+				continue;
+			Timecodes[i] = it->second;
+			if (!Timecodes[i].Timecode.empty())
+				TimecodeToIndex.emplace(Timecodes[i].Timecode, uint32_t(i));
+			FrameNumberToIndex.emplace(Timecodes[i].FrameNumber, uint32_t(i));
+		}
+	}
+
+	// --- Execution ---
+
+	bool ResolveFrameIndex(uint32_t& outIdx)
+	{
+		switch (Mode)
+		{
+		case PlaybackTrackMode::Timecode:
+		{
+			auto it = TimecodeToIndex.find(InTimecode);
+			if (it == TimecodeToIndex.end())
+				return false;
+			outIdx = it->second;
+			return true;
+		}
+		case PlaybackTrackMode::FrameNumber:
+		{
+			auto it = FrameNumberToIndex.find(InFrameNumber);
+			if (it == FrameNumberToIndex.end())
+				return false;
+			outIdx = it->second;
+			return true;
+		}
+		case PlaybackTrackMode::FrameIndex:
+		default:
+			outIdx = FrameIndex < (uint32_t)Frames.size() ? FrameIndex : (uint32_t)Frames.size() - 1;
+			return true;
+		}
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+		if (Frames.empty())
+		{
+			nos::track::TTrack empty{};
+			auto buf = nos::Buffer::From(empty);
+			SetPinValue(NOS_NAME("Track"), {.Data = buf.Data(), .Size = buf.Size()});
+			return NOS_RESULT_SUCCESS;
+		}
+
+		uint32_t frameIdx = 0;
+		if (!ResolveFrameIndex(frameIdx))
+			frameIdx = CurrentFrame < (uint32_t)Frames.size() ? CurrentFrame : 0;
+		CurrentFrame = frameIdx;
+
+		auto buf = nos::Buffer::From(Frames[frameIdx]);
+		SetPinValue(NOS_NAME("Track"), {.Data = buf.Data(), .Size = buf.Size()});
+		UpdateFrameIndexPin();
+
+		return NOS_RESULT_SUCCESS;
+	}
+
+	static nosResult GetFunctions(size_t* count, nosName* names, nosPfnNodeFunctionExecute* fns)
+	{
+		*count = 1;
+		if (!names || !fns)
+			return NOS_RESULT_SUCCESS;
+
+		names[0] = NOS_NAME_STATIC("PlaybackTrackCOLMAP_OpenFolder");
+		fns[0] = [](void* ctx, nosFunctionExecuteParams*) {
+			auto* self = static_cast<PlaybackTrackCOLMAPContext*>(ctx);
+			if (self->InputDir.empty())
+			{
+				nosEngine.LogW("PlaybackTrackCOLMAP: Input directory not set");
+				return NOS_RESULT_FAILED;
+			}
+			std::filesystem::path dir = nos::Utf8ToPath(self->InputDir);
+			if (!std::filesystem::exists(dir))
+			{
+				nosEngine.LogW("PlaybackTrackCOLMAP: Directory does not exist: %s", self->InputDir.c_str());
+				return NOS_RESULT_FAILED;
+			}
+			// TODO: Replace std::system with platform APIs (ShellExecuteW / posix_spawnp)
+#if defined(_WIN32)
+			std::string cmd = "explorer \"" + nos::PathToUtf8(dir) + "\"";
+#elif defined(__APPLE__)
+			std::string cmd = "open \"" + nos::PathToUtf8(dir) + "\"";
+#else
+			std::string cmd = "xdg-open \"" + nos::PathToUtf8(dir) + "\"";
+#endif
+			std::system(cmd.c_str());
+			return NOS_RESULT_SUCCESS;
+		};
+
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+void RegisterPlaybackTrackCOLMAP(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("PlaybackTrackCOLMAP"), PlaybackTrackCOLMAPContext, fn);
+}
+
+} // namespace nos::track

--- a/Plugins/nosTrack/Source/ReOriginTrack.cpp
+++ b/Plugins/nosTrack/Source/ReOriginTrack.cpp
@@ -1,0 +1,144 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include "nosTrack/Track_generated.h"
+
+#include <glm/glm.hpp>
+
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::track
+{
+
+NOS_REGISTER_NAME(Input);
+NOS_REGISTER_NAME(Output);
+NOS_REGISTER_NAME(CoordinateSystem);
+NOS_REGISTER_NAME(Origin);
+NOS_REGISTER_NAME(ReOriginTrack_MarkOrigin);
+NOS_REGISTER_NAME(ReOriginTrack_ClearOrigin);
+
+struct ReOriginTrackContext : NodeContext
+{
+	nos::track::Frame Frame = nos::track::UNREAL_SYSTEM;
+	nos::track::TTrack Origin;     // Marked reference pose (identity until marked).
+	nos::track::TTrack LatestInput; // Last input seen, captured by Mark Origin.
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		if (node->pins())
+		{
+			for (auto* pin : *node->pins())
+			{
+				if (!flatbuffers::IsFieldPresent(pin, fb::Pin::VT_DATA))
+					continue;
+				nosBuffer value = {.Data = (void*)pin->data()->data(), .Size = pin->data()->size()};
+				OnPinValueChanged(nos::Name(pin->name()->c_str()), *pin->id(), value);
+			}
+		}
+		UpdateStatus();
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinValueChanged(nos::Name pinName, uuid const& pinId, nosBuffer val) override
+	{
+		if (pinName == NSN_CoordinateSystem)
+			Frame = *static_cast<nos::track::Frame*>(val.Data);
+		else if (pinName == NSN_Origin)
+			flatbuffers::GetRoot<nos::track::Track>(val.Data)->UnPackTo(&Origin);
+	}
+
+	bool HasOrigin() const
+	{
+		auto const& l = Origin.location;
+		auto const& r = Origin.rotation;
+		return l.x() != 0 || l.y() != 0 || l.z() != 0 || r.x() != 0 || r.y() != 0 || r.z() != 0;
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+		auto inBuf = params.GetPinBuffer(NSN_Input);
+		if (!inBuf.Data)
+			return NOS_RESULT_SUCCESS;
+
+		auto* in = flatbuffers::GetRoot<nos::track::Track>(inBuf.Data);
+		if (!in)
+			return NOS_RESULT_SUCCESS;
+		in->UnPackTo(&LatestInput);
+
+		// Pass non-pose fields through; only location/rotation are re-origined.
+		nos::track::TTrack out = LatestInput;
+
+		// Rigid-body relative pose: out = inverse(T_origin) * T_input.
+		// transpose(R_origin) inverts the rotation; the translation is the input
+		// offset rotated into the origin's local frame. Frame-agnostic given a
+		// proper rotation matrix, and no unit conversion (origin and input share
+		// one coordinate system).
+		auto const& il = LatestInput.location;
+		auto const& ol = Origin.location;
+		glm::dmat3 R_origin = nos::track::EulerToMat(
+			Frame.euler(), glm::dvec3(Origin.rotation.x(), Origin.rotation.y(), Origin.rotation.z()));
+		glm::dmat3 R_in = nos::track::EulerToMat(
+			Frame.euler(), glm::dvec3(LatestInput.rotation.x(), LatestInput.rotation.y(), LatestInput.rotation.z()));
+		glm::dmat3 R_originT = glm::transpose(R_origin);
+
+		glm::dvec3 relPos = R_originT * glm::dvec3(il.x() - ol.x(), il.y() - ol.y(), il.z() - ol.z());
+		glm::dvec3 relRot = nos::track::MatToEuler(Frame.euler(), R_originT * R_in);
+
+		out.location = nos::fb::vec3((float)relPos.x, (float)relPos.y, (float)relPos.z);
+		out.rotation = nos::fb::vec3((float)relRot.x, (float)relRot.y, (float)relRot.z);
+
+		auto buf = nos::Buffer::From(out);
+		SetPinValue(NSN_Output, {.Data = buf.Data(), .Size = buf.Size()});
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void StoreOrigin()
+	{
+		auto buf = nos::Buffer::From(Origin);
+		SetPinValue(NSN_Origin, {.Data = buf.Data(), .Size = buf.Size()});
+	}
+
+	void UpdateStatus()
+	{
+		if (HasOrigin())
+			SetNodeStatusMessage("Origin marked", fb::NodeStatusMessageType::INFO);
+		else
+			SetNodeStatusMessage("No origin (pass-through)", fb::NodeStatusMessageType::INFO);
+	}
+
+	static nosResult GetFunctions(size_t* count, nosName* names, nosPfnNodeFunctionExecute* fns)
+	{
+		*count = 2;
+		if (!names || !fns)
+			return NOS_RESULT_SUCCESS;
+
+		names[0] = NOS_NAME_STATIC("ReOriginTrack_MarkOrigin");
+		fns[0] = [](void* ctx, nosFunctionExecuteParams*) {
+			auto* self = static_cast<ReOriginTrackContext*>(ctx);
+			self->Origin = self->LatestInput;
+			self->StoreOrigin();
+			self->UpdateStatus();
+			nosEngine.LogI("ReOriginTrack: Origin marked");
+			return NOS_RESULT_SUCCESS;
+		};
+
+		names[1] = NOS_NAME_STATIC("ReOriginTrack_ClearOrigin");
+		fns[1] = [](void* ctx, nosFunctionExecuteParams*) {
+			auto* self = static_cast<ReOriginTrackContext*>(ctx);
+			self->Origin = nos::track::TTrack{};
+			self->StoreOrigin();
+			self->UpdateStatus();
+			nosEngine.LogI("ReOriginTrack: Origin cleared");
+			return NOS_RESULT_SUCCESS;
+		};
+
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+void RegisterReOriginTrack(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("nos.track.ReOriginTrack"), ReOriginTrackContext, fn);
+}
+
+} // namespace nos::track

--- a/Plugins/nosTrack/Source/RecordTrackCOLMAP.cpp
+++ b/Plugins/nosTrack/Source/RecordTrackCOLMAP.cpp
@@ -1,0 +1,461 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include "nosTrack/Track_generated.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <fstream>
+#include <filesystem>
+#include <vector>
+#include <cmath>
+#include <iomanip>
+
+#include <nosTrack/CoordinateFrameConversion.hpp>
+
+namespace nos::track
+{
+
+NOS_REGISTER_NAME(OutputDirectory);
+NOS_REGISTER_NAME(ImageResolution);
+NOS_REGISTER_NAME(SourceFrame);
+NOS_REGISTER_NAME(Record);
+NOS_REGISTER_NAME(MinOffFrames);
+NOS_REGISTER_NAME(FrameCount);
+NOS_REGISTER_NAME(RecordingFrame);
+
+struct RecordedFrame
+{
+	glm::vec3 Location;
+	glm::vec3 Rotation; // Euler degrees in the SourceFrame's convention.
+	float FOV;
+	float Zoom;
+	float Focus;
+	float RenderRatio;
+	glm::vec2 SensorSize;
+	float PixelAspectRatio;
+	float NodalOffset;
+	float FocusDistance;
+	float K1;
+	float K2;
+	glm::vec2 CenterShift;
+	float DistortionScale;
+	std::string Timecode;
+	uint32_t FrameNumber;
+};
+
+struct RecordTrackCOLMAPContext : NodeContext
+{
+	std::string OutputDir;
+	nosVec2u ImageResolution = {1920, 1080};
+	nos::track::Frame SourceFrame = nos::track::UNREAL_SYSTEM;
+	bool Recording = false;
+	uint32_t ConsecutiveOffFrames = 0;
+	bool LastRequestRecord = false;
+	std::string LastError;
+	std::vector<RecordedFrame> Frames;
+	nosVec2u DeltaSeconds{}; // {numerator, denominator}; 0/0 if not in fixed-step mode
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		if (node->pins())
+		{
+			for (auto* pin : *node->pins())
+			{
+				auto name = nos::Name(pin->name()->c_str());
+				if (flatbuffers::IsFieldPresent(pin, fb::Pin::VT_DATA))
+				{
+					nosBuffer value = {.Data = (void*)pin->data()->data(), .Size = pin->data()->size()};
+					OnPinValueChanged(name, *pin->id(), value);
+				}
+			}
+		}
+		UpdateStatus();
+		return NOS_RESULT_SUCCESS;
+	}
+
+	bool StartRecording()
+	{
+		std::string error;
+		if (!CanStartRecording(error))
+		{
+			LastError = std::move(error);
+			UpdateStatus();
+			return false;
+		}
+		LastError.clear();
+		Frames.clear();
+		Recording = true;
+		ConsecutiveOffFrames = 0;
+		UpdateFrameCountPin();
+		UpdateRecordingFramePin();
+		UpdateStatus();
+		nosEngine.LogI("RecordTrackCOLMAP: Recording started");
+		return true;
+	}
+
+	void StopRecording()
+	{
+		Recording = false;
+		nosEngine.LogI("RecordTrackCOLMAP: Recording stopped (%zu frames in buffer)", Frames.size());
+		if (!Frames.empty())
+			WriteFiles();
+		Frames.clear();
+		UpdateFrameCountPin();
+		UpdateRecordingFramePin();
+		UpdateStatus();
+	}
+
+	void OnPinValueChanged(nos::Name pinName, uuid const& pinId, nosBuffer val) override
+	{
+		if (pinName == NSN_OutputDirectory)
+		{
+			OutputDir = static_cast<const char*>(val.Data);
+			LastError.clear();
+			UpdateStatus();
+		}
+		else if (pinName == NSN_ImageResolution)
+			ImageResolution = *(nosVec2u*)val.Data;
+		else if (pinName == NSN_SourceFrame)
+			SourceFrame = *(nos::track::Frame*)val.Data;
+	}
+
+	bool CanStartRecording(std::string& outError)
+	{
+		if (OutputDir.empty())
+		{
+			outError = "Set output directory";
+			return false;
+		}
+
+		std::filesystem::path outDir = nos::Utf8ToPath(OutputDir);
+		try
+		{
+			if (std::filesystem::exists(outDir) && !std::filesystem::is_empty(outDir))
+			{
+				outError = "Target folder is not empty";
+				return false;
+			}
+		}
+		catch (std::filesystem::filesystem_error& e)
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: %s", e.what());
+			outError = e.what();
+			return false;
+		}
+		return true;
+	}
+
+	void UpdateFrameCountPin()
+	{
+		uint32_t count = (uint32_t)Frames.size();
+		SetPinValue(NSN_FrameCount, nosBuffer{.Data = &count, .Size = sizeof(count)});
+	}
+
+	void UpdateRecordingFramePin()
+	{
+		uint32_t frame = Recording ? (uint32_t)Frames.size() : 0;
+		SetPinValue(NSN_RecordingFrame, nosBuffer{.Data = &frame, .Size = sizeof(frame)});
+	}
+
+	void UpdateStatus()
+	{
+		if (!LastError.empty())
+			SetNodeStatusMessage(LastError, fb::NodeStatusMessageType::FAILURE);
+		else if (OutputDir.empty())
+			SetNodeStatusMessage("Set output directory", fb::NodeStatusMessageType::WARNING);
+		else if (Recording)
+			SetNodeStatusMessage("Recording (" + std::to_string(Frames.size()) + " frames)", fb::NodeStatusMessageType::INFO);
+		else
+			SetNodeStatusMessage("Idle", fb::NodeStatusMessageType::INFO);
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& params) override
+	{
+		if (params.TimingMode == NOS_EXECUTION_TIMING_MODE_FIXED_STEP)
+			DeltaSeconds = params.FixedStepTiming.DeltaSeconds;
+
+		// Pass through Track input to output
+		auto trackBuf = params.GetPinBuffer(NOS_NAME("InTrack"));
+		SetPinValue(NOS_NAME("OutTrack"), trackBuf);
+
+		// Drive recording state from the Record pin, with off-state debouncing to
+		// ride out brief glitches in the upstream signal (e.g. SDI bit flips on a
+		// camera-derived recording flag). Start happens immediately on a rising
+		// edge; stop only after MinOffFrames consecutive false frames.
+		const bool requestRecord = *params.GetPinValue<bool>(NSN_Record);
+		const uint32_t minOffFrames = *params.GetPinValue<uint32_t>(NSN_MinOffFrames);
+
+		const bool risingEdge = requestRecord && !LastRequestRecord;
+		LastRequestRecord = requestRecord;
+
+		if (risingEdge && !Recording)
+			StartRecording();
+
+		if (Recording)
+		{
+			if (requestRecord)
+				ConsecutiveOffFrames = 0;
+			else if (++ConsecutiveOffFrames >= std::max(1u, minOffFrames))
+				StopRecording();
+		}
+
+		if (!Recording)
+			return NOS_RESULT_SUCCESS;
+
+		auto* trackData = flatbuffers::GetRoot<nos::track::Track>(trackBuf.Data);
+		if (!trackData)
+			return NOS_RESULT_SUCCESS;
+
+		RecordedFrame frame{};
+		if (const char* tc = params.GetPinValue<const char>(NOS_NAME_STATIC("Timecode")))
+			frame.Timecode = tc;
+		frame.FrameNumber = *params.GetPinValue<uint32_t>(NOS_NAME_STATIC("FrameNumber"));
+		if (auto* loc = trackData->location())
+			frame.Location = {loc->x(), loc->y(), loc->z()};
+		if (auto* rot = trackData->rotation())
+			frame.Rotation = {rot->x(), rot->y(), rot->z()};
+		frame.FOV = trackData->fov();
+		frame.Zoom = trackData->zoom();
+		frame.Focus = trackData->focus();
+		frame.RenderRatio = trackData->render_ratio();
+		if (auto* ss = trackData->sensor_size())
+			frame.SensorSize = {ss->x(), ss->y()};
+		frame.PixelAspectRatio = trackData->pixel_aspect_ratio();
+		frame.NodalOffset = trackData->nodal_offset();
+		frame.FocusDistance = trackData->focus_distance();
+		if (auto* ld = trackData->lens_distortion())
+		{
+			frame.K1 = ld->k1k2().x();
+			frame.K2 = ld->k1k2().y();
+			frame.CenterShift = {ld->center_shift().x(), ld->center_shift().y()};
+			frame.DistortionScale = ld->distortion_scale();
+		}
+		Frames.push_back(frame);
+
+		UpdateFrameCountPin();
+		UpdateRecordingFramePin();
+		UpdateStatus();
+
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void WriteFiles()
+	{
+		if (OutputDir.empty())
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: Output directory is empty");
+			return;
+		}
+		if (Frames.empty())
+		{
+			nosEngine.LogW("RecordTrackCOLMAP: No frames recorded");
+			return;
+		}
+
+		std::filesystem::path outDir = nos::Utf8ToPath(OutputDir);
+		try
+		{
+			if (!std::filesystem::exists(outDir))
+				std::filesystem::create_directories(outDir);
+		}
+		catch (std::filesystem::filesystem_error& e)
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: %s", e.what());
+			return;
+		}
+
+		WriteCamerasTxt(outDir);
+		WriteImagesTxt(outDir);
+		WriteTimecodesTxt(outDir);
+		WriteExtrasTxt(outDir);
+		nosEngine.LogI("RecordTrackCOLMAP: Saved %zu frames to %s", Frames.size(), OutputDir.c_str());
+	}
+
+	void WriteExtrasTxt(const std::filesystem::path& outDir)
+	{
+		// Sidecar for Track fields that don't fit COLMAP's standard cameras.txt /
+		// images.txt format. Keyed by IMAGE_ID so it pairs 1:1 with images.txt.
+		auto path = outDir / "extras.txt";
+		std::ofstream file(path);
+		if (!file.is_open())
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: Cannot open %s", nos::PathToUtf8(path).c_str());
+			return;
+		}
+		const std::string frameName =
+			std::string("up=") + nos::track::EnumNameSignedAxis(SourceFrame.up())
+			+ " forward=" + nos::track::EnumNameSignedAxis(SourceFrame.forward())
+			+ " handedness=" + nos::track::EnumNameHandedness(SourceFrame.handedness())
+			+ " euler_order=" + nos::track::EnumNameEulerOrder(SourceFrame.euler().order())
+			+ " euler_sign=" + std::to_string((int)SourceFrame.euler().sign_x())
+			+ "," + std::to_string((int)SourceFrame.euler().sign_y())
+			+ "," + std::to_string((int)SourceFrame.euler().sign_z());
+		file << std::setprecision(12);
+		file << "# Nodos Track sidecar paired with images.txt by IMAGE_ID.\n";
+		file << "# Carries fields that don't fit COLMAP's cameras.txt/images.txt:\n";
+		file << "#   - sensor_size in mm (cameras.txt only stores pixel WIDTH/HEIGHT)\n";
+		file << "#   - original Euler rotation in degrees (avoids quaternion round-trip drift)\n";
+		file << "#   - nodos-only fields with no COLMAP equivalent\n";
+		file << "# SourceFrame: " << frameName << " (Euler convention used for ROT_X, ROT_Y, ROT_Z below).\n";
+		file << "# IMAGE_ID, ZOOM, FOCUS, FOCUS_DISTANCE, RENDER_RATIO, NODAL_OFFSET, DISTORTION_SCALE, SENSOR_W_MM, SENSOR_H_MM, ROT_X, ROT_Y, ROT_Z\n";
+		file << "# Number of entries: " << Frames.size() << "\n";
+		for (size_t i = 0; i < Frames.size(); ++i)
+		{
+			const auto& f = Frames[i];
+			file << (i + 1) << " "
+				 << f.Zoom << " "
+				 << f.Focus << " "
+				 << f.FocusDistance << " "
+				 << f.RenderRatio << " "
+				 << f.NodalOffset << " "
+				 << f.DistortionScale << " "
+				 << f.SensorSize.x << " " << f.SensorSize.y << " "
+				 << f.Rotation.x << " " << f.Rotation.y << " " << f.Rotation.z << "\n";
+		}
+	}
+
+	void WriteTimecodesTxt(const std::filesystem::path& outDir)
+	{
+		// Skip the sidecar entirely if no frame carried a timecode -- keeps the
+		// output minimal when the upstream graph isn't producing TC.
+		bool any = false;
+		for (auto& f : Frames)
+			if (!f.Timecode.empty() || f.FrameNumber != 0) { any = true; break; }
+		if (!any)
+			return;
+
+		auto path = outDir / "timecodes.txt";
+		std::ofstream file(path);
+		if (!file.is_open())
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: Cannot open %s", nos::PathToUtf8(path).c_str());
+			return;
+		}
+		double dt = (DeltaSeconds.y != 0) ? (double)DeltaSeconds.x / (double)DeltaSeconds.y : 0.0;
+		file << "# Timecode sidecar paired with images.txt by IMAGE_ID.\n";
+		file << "# First non-comment line: per-frame delta seconds (0 if recording wasn't in fixed-step timing).\n";
+		file << "# IMAGE_ID, TIMECODE, FRAME_NUMBER\n";
+		file << "# Number of entries: " << Frames.size() << "\n";
+		file << std::setprecision(12) << dt << "\n";
+		for (size_t i = 0; i < Frames.size(); ++i)
+		{
+			const auto& f = Frames[i];
+			file << (i + 1) << " "
+				 << (f.Timecode.empty() ? "-" : f.Timecode) << " "
+				 << f.FrameNumber << "\n";
+		}
+	}
+
+	float ComputeFocalLengthPixels(const RecordedFrame& frame) const
+	{
+		if (frame.FOV <= 0.0f)
+			return static_cast<float>(ImageResolution.x);
+		float fovRad = glm::radians(frame.FOV);
+		return (ImageResolution.x * 0.5f) / std::tan(fovRad * 0.5f);
+	}
+
+	void WriteCamerasTxt(const std::filesystem::path& outDir)
+	{
+		auto path = outDir / "cameras.txt";
+		std::ofstream file(path);
+		if (!file.is_open())
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: Cannot open %s", nos::PathToUtf8(path).c_str());
+			return;
+		}
+
+		file << std::setprecision(12);
+		file << "# COLMAP camera intrinsics. Standard format (colmap.github.io/format.html).\n";
+		file << "# OPENCV model: PARAMS = fx, fy, cx, cy, k1, k2, p1, p2 (pixels).\n";
+		file << "# Camera list with one line of data per camera:\n";
+		file << "# CAMERA_ID, MODEL, WIDTH, HEIGHT, PARAMS[]\n";
+		file << "# Number of cameras: " << Frames.size() << "\n";
+
+		for (size_t i = 0; i < Frames.size(); ++i)
+		{
+			float fx = ComputeFocalLengthPixels(Frames[i]);
+			float fy = fx;
+			if (Frames[i].PixelAspectRatio > 0.0f)
+				fy = fx / Frames[i].PixelAspectRatio;
+
+			// center_shift is in the same units as sensor_size (mm); convert to
+			// pixel offset on the principal point. See TrackToView.cpp:30 for the
+			// canonical centerShift / sensorSize relationship.
+			float cx = ImageResolution.x * 0.5f;
+			float cy = ImageResolution.y * 0.5f;
+			if (Frames[i].SensorSize.x > 0.0f)
+				cx += Frames[i].CenterShift.x * ImageResolution.x / Frames[i].SensorSize.x;
+			if (Frames[i].SensorSize.y > 0.0f)
+				cy += Frames[i].CenterShift.y * ImageResolution.y / Frames[i].SensorSize.y;
+
+			float k1 = Frames[i].K1;
+			float k2 = Frames[i].K2;
+
+			file << (i + 1) << " OPENCV " << ImageResolution.x << " " << ImageResolution.y << " "
+				 << fx << " " << fy << " " << cx << " " << cy << " "
+				 << k1 << " " << k2 << " 0 0\n";
+		}
+	}
+
+	void WriteImagesTxt(const std::filesystem::path& outDir)
+	{
+		auto path = outDir / "images.txt";
+		std::ofstream file(path);
+		if (!file.is_open())
+		{
+			nosEngine.LogE("RecordTrackCOLMAP: Cannot open %s", nos::PathToUtf8(path).c_str());
+			return;
+		}
+
+		file << std::setprecision(12);
+		file << "# COLMAP poses. Standard format (colmap.github.io/format.html).\n";
+		file << "# Frame: RH, +X right, +Y down, +Z forward (camera looks along +Z).\n";
+		file << "# (QW, QX, QY, QZ) is the world-to-camera rotation R_w2c.\n";
+		file << "# (TX, TY, TZ) is the world-to-camera translation: t = -R_w2c * camera_world_position.\n";
+		file << "# Recover camera position in the COLMAP world frame as: C = -R_w2c^T * t.\n";
+		file << "# Image list with two lines of data per image:\n";
+		file << "# IMAGE_ID, QW, QX, QY, QZ, TX, TY, TZ, CAMERA_ID, NAME\n";
+		file << "# POINTS2D[] as (X, Y, POINT3D_ID)\n";
+		file << "# Number of images: " << Frames.size() << "\n";
+
+		// M maps the SourceFrame to the COLMAP frame. Used to convert both the
+		// source-frame R_c2w and the source-frame camera position into COLMAP.
+		// Positions are also scaled into COLMAP's units (meters) by the ratio of
+		// the two systems' meters_per_unit.
+		const glm::dmat3 M = nos::track::BasisChangeToColmap(SourceFrame);
+		const glm::dmat3 Minv = glm::inverse(M);
+		const double unitFactor = nos::track::UnitFactor(SourceFrame, nos::track::COLMAP_SYSTEM);
+
+		for (size_t i = 0; i < Frames.size(); ++i)
+		{
+			auto& frame = Frames[i];
+
+			// Build R_c2w in the source frame, then conjugate by M to land in
+			// the COLMAP frame. Likewise frame the position.
+			glm::dmat3 R_c2w_src = nos::track::EulerToMat(SourceFrame.euler(), glm::dvec3(frame.Rotation));
+			glm::dmat3 R_c2w_colmap = M * R_c2w_src * Minv;
+			glm::dvec3 pos_colmap = M * glm::dvec3(frame.Location) * unitFactor;
+
+			glm::dmat3 R_w2c = glm::transpose(R_c2w_colmap);
+			glm::dquat q_w2c = glm::quat_cast(R_w2c);
+			glm::dvec3 t = -R_w2c * pos_colmap;
+
+			file << (i + 1) << " "
+				 << q_w2c.w << " " << q_w2c.x << " " << q_w2c.y << " " << q_w2c.z << " "
+				 << t.x << " " << t.y << " " << t.z << " "
+				 << (i + 1) << " "
+				 << "frame_" << std::setfill('0') << std::setw(6) << i << ".png\n";
+			// Empty points line (required by COLMAP format)
+			file << "\n";
+		}
+	}
+};
+
+void RegisterRecordTrackCOLMAP(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("RecordTrackCOLMAP"), RecordTrackCOLMAPContext, fn);
+}
+
+} // namespace nos::track

--- a/Plugins/nosTrack/Source/TrackMain.cpp
+++ b/Plugins/nosTrack/Source/TrackMain.cpp
@@ -21,12 +21,22 @@ enum TrackNode : int
 	FreeD,
 	UserTrack,
 	AddTrack,
+	ConvertTrackFrame,
+	ConvertTransform,
+	PlaybackTrackCOLMAP,
+	ReOriginTrack,
+	RecordTrackCOLMAP,
 	Count
 };
 
 void RegisterFreeDNode(nosNodeFunctions* functions);
 void RegisterController(nosNodeFunctions* functions);
 void RegisterAddTrack(nosNodeFunctions*);
+void RegisterConvertTrackFrame(nosNodeFunctions*);
+void RegisterConvertTransform(nosNodeFunctions*);
+void RegisterPlaybackTrackCOLMAP(nosNodeFunctions*);
+void RegisterReOriginTrack(nosNodeFunctions*);
+void RegisterRecordTrackCOLMAP(nosNodeFunctions*);
 
 nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outSize, nosNodeFunctions** outList)
 {
@@ -46,7 +56,22 @@ nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outSize, nosNodeFunctions** ou
 			RegisterController(node);
 			break;
 		case TrackNode::AddTrack:
-			RegisterAddTrack(node); 
+			RegisterAddTrack(node);
+			break;
+		case TrackNode::ConvertTrackFrame:
+			RegisterConvertTrackFrame(node);
+			break;
+		case TrackNode::ConvertTransform:
+			RegisterConvertTransform(node);
+			break;
+		case TrackNode::PlaybackTrackCOLMAP:
+			RegisterPlaybackTrackCOLMAP(node);
+			break;
+		case TrackNode::ReOriginTrack:
+			RegisterReOriginTrack(node);
+			break;
+		case TrackNode::RecordTrackCOLMAP:
+			RegisterRecordTrackCOLMAP(node);
 			break;
 		}
 	}
@@ -149,7 +174,7 @@ NOSAPI_ATTR nosResult NOSAPI_CALL nosExportPlugin(nosPluginFunctions* outFunctio
 
 	nosAnimationInterpolator transformInterpolator = {.TypeName = NOS_NAME(fb::Transform::GetFullyQualifiedName()),
 											 .InterpolateCallback = InterpolateTransform};
-	nosAnimation->RegisterInterpolator(&trackInterpolator);
+	nosAnimation->RegisterInterpolator(&transformInterpolator);
 
 
 	return NOS_RESULT_SUCCESS;

--- a/Plugins/nosTrack/Tests/ConvertTransform_SameFrameIsIdentity_Parity.nosa
+++ b/Plugins/nosTrack/Tests/ConvertTransform_SameFrameIsIdentity_Parity.nosa
@@ -1,0 +1,544 @@
+{
+  "info": {
+    "version": "1.4.0.b0",
+    "loaded_modules": [
+      {
+        "name": "nos.test",
+        "version": "0.3.1"
+      },
+      {
+        "name": "nos.reflect",
+        "version": "3.0.0"
+      },
+      {
+        "name": "nos.track",
+        "version": "3.0.0"
+      }
+    ]
+  },
+  "graph": {
+    "id": "b27a5a94-5186-4624-bdf8-2022a46c0577",
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "contents_type": "Graph",
+    "contents": {
+      "nodes": [
+        {
+          "id": "f0212443-e603-422a-94cb-987b891b6e41",
+          "name": "Thread",
+          "class_name": "nos.Thread",
+          "pins": [
+            {
+              "id": "37b9e07a-d3d9-48fa-8a1a-9f7ac1320018",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "live": true
+            },
+            {
+              "id": "0653bcca-58bb-485e-8b91-a31b4ffa2201",
+              "name": "Importance",
+              "type_name": "ulong",
+              "show_as": "PROPERTY",
+              "can_show_as": "PROPERTY_ONLY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 86,
+            "y": -94
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          },
+          "always_execute": true
+        },
+        {
+          "id": "6b99ef91-ae2a-43ea-a566-b06da4c4c5f6",
+          "name": "TestScheduler",
+          "class_name": "nos.test.TestScheduler",
+          "pins": [
+            {
+              "id": "f6c97e9d-2314-4db3-b9a1-54c3382d306b",
+              "name": "Run",
+              "type_name": "nos.exe",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": {},
+              "def": {},
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "f58ddd17-d533-4021-a289-5a155bd9246a",
+              "name": "Sink",
+              "type_name": "uint",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "5c8a9543-84d4-48ef-a067-5da25d5b86cd",
+              "name": "FreeRun",
+              "type_name": "bool",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": false,
+              "def": false,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "292ef23b-e4bf-496c-b814-a0b10d50f93f",
+              "name": "DeltaTime",
+              "type_name": "nos.fb.vec2u",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "x": 1,
+                "y": 60
+              },
+              "def": {
+                "x": 1,
+                "y": 60
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": 324,
+            "y": 7
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "0a8817d3-b6d6-4d41-aeb3-b0d1d1faf277",
+          "name": "Assert",
+          "class_name": "nos.test.Assert",
+          "pins": [
+            {
+              "id": "8f5730b3-b273-4f8f-bec8-be04bab618d5",
+              "name": "Behaviour",
+              "type_name": "nos.test.AssertionBehaviour",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": "EXIT_WITH_STATUS_CODE",
+              "def": "EXIT_WITH_STATUS_CODE",
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "cf4fd7f3-69e5-4645-829b-bc004a394f19",
+              "name": "NumFramesToWait",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 0,
+              "def": 0,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "a2aa0228-4514-4512-b403-4e55181947c2",
+              "name": "FrameCount",
+              "type_name": "uint",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "4e7952c9-9199-4fe3-a09b-3db3de9fb9bf",
+              "name": "Condition",
+              "type_name": "bool",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "9e14196b-c17b-4fc7-ae44-3439c385775c",
+              "name": "NumFramesToAssertOver",
+              "type_name": "uint",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": 1,
+              "def": 1,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "min": 1
+            }
+          ],
+          "pos": {
+            "x": 93,
+            "y": 11
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 3,
+            "patch": 1
+          }
+        },
+        {
+          "id": "d356481b-56b1-40ed-af11-30fcf64a7d9c",
+          "name": "IsEqual",
+          "class_name": "nos.reflect.IsEqual",
+          "pins": [
+            {
+              "id": "87991911-d2e9-48df-80b0-8cc03a76958c",
+              "name": "A",
+              "type_name": "nos.fb.Transform",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "def": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "2594673c-51ab-4ddc-be77-36cd289fd6a0",
+              "name": "B",
+              "type_name": "nos.fb.Transform",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "data": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "def": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            },
+            {
+              "id": "6ee02795-e6e6-4350-a9d4-d3fe7ebadc84",
+              "name": "IsEqual",
+              "type_name": "bool",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_ONLY",
+              "visualizers": [],
+              "data": true,
+              "def": true,
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -105,
+            "y": 4
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 0
+          }
+        },
+        {
+          "id": "3ac6b9de-1b24-4b84-9176-357af4a3f31a",
+          "name": "ConvertTransform",
+          "class_name": "nos.track.ConvertTransform",
+          "pins": [
+            {
+              "id": "1541f49f-421e-4109-864f-7a31c5d71f7a",
+              "name": "In",
+              "type_name": "nos.fb.Transform",
+              "show_as": "INPUT_PIN",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              },
+              "def": {
+                "position": {
+                  "x": 1.0,
+                  "y": 2.0,
+                  "z": 3.0
+                },
+                "rotation": {
+                  "x": 0.0,
+                  "y": 0.0,
+                  "z": 0.0
+                },
+                "scale": {
+                  "x": 1.0,
+                  "y": 1.0,
+                  "z": 1.0
+                }
+              }
+            },
+            {
+              "id": "c2de12f7-a737-4ce3-b0ef-498e33cd0793",
+              "name": "SourceFrame",
+              "type_name": "nos.track.CoordinateFrame",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "up": "PosZ",
+                "forward": "PosX",
+                "handedness": "LeftHanded",
+                "euler": {
+                  "order": "ZYX",
+                  "sign_x": -1,
+                  "sign_y": -1,
+                  "sign_z": 1
+                },
+                "meters_per_unit": 0.01
+              },
+              "def": {
+                "up": "PosZ",
+                "forward": "PosX",
+                "handedness": "LeftHanded",
+                "euler": {
+                  "order": "ZYX",
+                  "sign_x": -1,
+                  "sign_y": -1,
+                  "sign_z": 1
+                },
+                "meters_per_unit": 0.01
+              }
+            },
+            {
+              "id": "98cd5b30-a2d6-446f-9ba8-3d732d985398",
+              "name": "TargetFrame",
+              "type_name": "nos.track.CoordinateFrame",
+              "show_as": "PROPERTY",
+              "can_show_as": "INPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {},
+              "data": {
+                "up": "PosZ",
+                "forward": "PosX",
+                "handedness": "LeftHanded",
+                "euler": {
+                  "order": "ZYX",
+                  "sign_x": -1,
+                  "sign_y": -1,
+                  "sign_z": 1
+                },
+                "meters_per_unit": 0.01
+              },
+              "def": {
+                "up": "PosZ",
+                "forward": "PosX",
+                "handedness": "LeftHanded",
+                "euler": {
+                  "order": "ZYX",
+                  "sign_x": -1,
+                  "sign_y": -1,
+                  "sign_z": 1
+                },
+                "meters_per_unit": 0.01
+              }
+            },
+            {
+              "id": "cfda2c9f-12d2-4e0c-a368-9a88dd8d168e",
+              "name": "Out",
+              "type_name": "nos.fb.Transform",
+              "show_as": "OUTPUT_PIN",
+              "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+              "visualizers": [],
+              "contents_type": "JobPin",
+              "contents": {},
+              "orphan_state": {}
+            }
+          ],
+          "pos": {
+            "x": -266,
+            "y": 14
+          },
+          "contents_type": "Job",
+          "contents": {
+            "type": ""
+          },
+          "function_category": "Default Node",
+          "plugin_version": {
+            "major": 0,
+            "minor": 0,
+            "patch": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "from": "37b9e07a-d3d9-48fa-8a1a-9f7ac1320018",
+          "to": "f6c97e9d-2314-4db3-b9a1-54c3382d306b",
+          "id": "6afbf552-53c0-4f29-8e8f-4ca634aa735b"
+        },
+        {
+          "from": "a2aa0228-4514-4512-b403-4e55181947c2",
+          "to": "f58ddd17-d533-4021-a289-5a155bd9246a",
+          "id": "1015e7f3-68e6-4001-b5c6-790144134949"
+        },
+        {
+          "from": "6ee02795-e6e6-4350-a9d4-d3fe7ebadc84",
+          "to": "4e7952c9-9199-4fe3-a09b-3db3de9fb9bf",
+          "id": "08d316b3-3a2b-40b3-88db-d0f80547a817"
+        },
+        {
+          "from": "cfda2c9f-12d2-4e0c-a368-9a88dd8d168e",
+          "to": "87991911-d2e9-48df-80b0-8cc03a76958c",
+          "id": "0d6ba5b2-9702-4fec-818a-f2348590aa96"
+        }
+      ]
+    },
+    "plugin_version": {
+      "major": 0,
+      "minor": 0,
+      "patch": 0
+    }
+  }
+}

--- a/Plugins/nosTrack/Track.nosplugin
+++ b/Plugins/nosTrack/Track.nosplugin
@@ -10,6 +10,10 @@
 			{
 				"name": "nos.sys.animation",
 				"version": "3.0"
+			},
+			{
+				"name": "nos.math",
+				"version": "2.0"
 			}
 		]
 	},

--- a/Plugins/nosTrack/Types/CoordinateSystemPresets.json
+++ b/Plugins/nosTrack/Types/CoordinateSystemPresets.json
@@ -1,0 +1,49 @@
+{
+    "name": "nos.track.CoordinateSystemPresets",
+    "values": [
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "Unreal"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "OpenGL-glTF"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "NegY", "forward": "PosZ", "handedness": "RightHanded", "euler": { "order": "YXZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "OpenCV-COLMAP"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "PosZ", "handedness": "LeftHanded", "euler": { "order": "ZXY", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Unity"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "Maya"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosY", "forward": "NegZ", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Houdini"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "PosY", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+            "value_name": "3dsMax"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "pin_value": { "up": "PosZ", "forward": "NegY", "handedness": "RightHanded", "euler": { "order": "XYZ", "sign_x": 1, "sign_y": 1, "sign_z": 1 }, "meters_per_unit": 1.0 },
+            "value_name": "Blender"
+        },
+        {
+            "type_name": "nos.track.CoordinateFrame",
+            "value_name": "Custom"
+        }
+    ]
+}

--- a/Plugins/nosTrack/Types/Coordinates.fbs
+++ b/Plugins/nosTrack/Types/Coordinates.fbs
@@ -1,0 +1,69 @@
+include "Common.fbs";
+
+// Shared coordinate-system / transform types, owned by nos.track (the lowest-level
+// shared plugin). nos.graphics and nos.geometry depend on nos.track and use these
+// via nos.track.* — this avoids a circular nos.graphics<->nos.track dependency.
+// The engine requires a plugin's fbs types to be in the plugin's own namespace,
+// so these are nos.track.* (NOT nos.graphics.*).
+namespace nos.track;
+
+// A signed coordinate axis, used to map world-semantic directions onto engine axes.
+enum SignedAxis : ubyte { PosX, NegX, PosY, NegY, PosZ, NegZ }
+
+// Chirality of the coordinate system.
+enum Handedness : ubyte { RightHanded, LeftHanded }
+
+// Intrinsic Euler rotation order. Component i of an Euler triple is always the
+// angle about axis i (rot.x about X, rot.y about Y, rot.z about Z).
+enum EulerOrder : ubyte { ZYX, XYZ, YXZ, YZX, ZXY, XZY }
+
+// How a 3-component Euler-angle field (degrees) is decoded into a rotation.
+struct EulerEncoding {
+    order: EulerOrder;
+    sign_x: byte;
+    sign_y: byte;
+    sign_z: byte;
+}
+
+// Full convention of a transform endpoint: axis assignments to world-semantic
+// directions (forward, up), the implied handedness, how its Euler-angle fields are
+// decoded (`euler`), and the unit scale. `right` is DERIVED and not stored.
+struct CoordinateFrame {
+    up: SignedAxis;
+    forward: SignedAxis;
+    handedness: Handedness;
+    euler: EulerEncoding;
+    // Linear size of one unit, in meters (cm = 0.01, m = 1.0).
+    meters_per_unit: double;
+}
+
+struct Transform {
+    position: nos.fb.vec3d;
+    rotation: nos.fb.vec3d;
+    scale:    nos.fb.vec3d;
+}
+
+// Like Transform, but rotation is a quaternion (x, y, z, w).
+struct TransformQ {
+    position: nos.fb.vec3d;
+    rotation: nos.fb.vec4d;
+    scale:    nos.fb.vec3d;
+}
+
+enum AlignmentState : ubyte {
+    Aligned = 0,         // within tolerance
+    NeedsCorrection = 1, // a move and/or turn is required
+}
+
+// Egocentric correction to bring a Source transform onto a Target, as computed
+// by CameraGuide. Translation is along Source's local axes; rotation is in
+// operator terms (degrees).
+struct TransformGuidance {
+    alignment: AlignmentState;
+    forward:   float; // +forward / -back
+    right:     float; // +right / -left
+    up:        float; // +up / -down
+    pan:       float; // degrees, + = pan right
+    tilt:      float; // degrees, + = tilt up
+    roll:      float; // degrees, + = roll CCW (operator looking along forward)
+}

--- a/Plugins/nosTrack/Types/PlaybackMode.fbs
+++ b/Plugins/nosTrack/Types/PlaybackMode.fbs
@@ -1,0 +1,9 @@
+namespace nos.track;
+
+// Selects how PlaybackTrackCOLMAP indexes into the recorded frames.
+enum PlaybackTrackMode : uint
+{
+    FrameIndex = 0,  // Use the InFrameIndex pin as a 0-based offset.
+    Timecode = 1,    // Look up by Timecode string from timecodes.txt.
+    FrameNumber = 2, // Look up by FrameNumber column from timecodes.txt.
+}

--- a/Plugins/nosUtilities/CMakeLists.txt
+++ b/Plugins/nosUtilities/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+# FreeType (submodule under External/freetype) is a self-contained SDF font
+# rasterizer for the TextRender node. All optional codec deps are disabled so it
+# builds with no external dependencies. Guarded so it never clashes with a
+# "freetype" target another plugin may create.
+if (NOT TARGET freetype)
+    set(FT_DISABLE_ZLIB ON CACHE BOOL "" FORCE)
+    set(FT_DISABLE_BZIP2 ON CACHE BOOL "" FORCE)
+    set(FT_DISABLE_PNG ON CACHE BOOL "" FORCE)
+    set(FT_DISABLE_HARFBUZZ ON CACHE BOOL "" FORCE)
+    set(FT_DISABLE_BROTLI ON CACHE BOOL "" FORCE)
+    add_subdirectory(External/freetype EXCLUDE_FROM_ALL)
+    nos_group_targets("freetype" "External")
+endif()
+
+target_link_libraries(${NOS_PLUGIN_TARGET} PRIVATE freetype)

--- a/Plugins/nosUtilities/Nodes/Counter.nosnode
+++ b/Plugins/nosUtilities/Nodes/Counter.nosnode
@@ -1,0 +1,56 @@
+{
+	"nodes": [
+		{
+			"class_name": "Counter",
+			"menu_info": {
+				"category": "Utilities",
+				"display_name": "Counter",
+				"aliases": [ "counter", "increment", "tally", "index" ]
+			},
+			"node": {
+				"class_name": "Counter",
+				"display_name": "Counter",
+				"contents_type": "Job",
+				"description": "Outputs a running count that advances by Step every time the node runs.\nDrive it through the In/Out exe pins to schedule it, and call Reset to zero the count.",
+				"pins": [
+					{
+						"name": "InExe",
+						"type_name": "nos.exe",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "OutExe",
+						"type_name": "nos.exe",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					},
+					{
+						"name": "Step",
+						"description": "Amount added to the count on each run. Use a negative value to count down.",
+						"type_name": "int",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 1
+					},
+					{
+						"name": "Count",
+						"description": "The current count. Advances by Step on each run; zeroed by Reset.",
+						"type_name": "ulong",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"data": 0
+					}
+				],
+				"functions": [
+					{
+						"class_name": "Reset",
+						"contents_type": "Job",
+						"description": "Zeroes the count.",
+						"pins": []
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosUtilities/Nodes/TextRender.nosnode
+++ b/Plugins/nosUtilities/Nodes/TextRender.nosnode
@@ -1,0 +1,275 @@
+{
+	"nodes": [
+		{
+			"class_name": "TextRender",
+			"menu_info": {
+				"category": "Utilities",
+				"display_name": "Text Render",
+				"name_aliases": [ "text", "font", "label", "caption", "subtitle", "string to texture" ]
+			},
+			"node": {
+				"class_name": "TextRender",
+				"contents_type": "Job",
+				"description": "Renders text into a texture using a signed distance field font atlas.\nSupports multi-line text, word wrapping, outline, drop shadow and a text-box background.",
+				"pins": [
+					{
+						"name": "Text",
+						"type_name": "string",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": "Text",
+						"description": "Text to render. Newlines and word wrapping are honored."
+					},
+					{
+						"name": "FontSize",
+						"display_name": "Font Size",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Font" }
+						],
+						"data": 64.0,
+						"min": 1.0,
+						"description": "Glyph height in pixels."
+					},
+					{
+						"name": "Color",
+						"type_name": "nos.fb.vec4",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"visualizer": {
+							"type": "COLOR_PICKER"
+						},
+						"data": {
+							"x": 1,
+							"y": 1,
+							"z": 1,
+							"w": 1
+						},
+						"description": "Fill color of the text."
+					},
+					{
+						"name": "Opacity",
+						"type_name": "float",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": 1.0,
+						"min": 0.0,
+						"max": 1.0,
+						"description": "Global opacity multiplier applied to text, outline, shadow and background."
+					},
+					{
+						"name": "StrokeColor",
+						"display_name": "Stroke Color",
+						"type_name": "nos.fb.vec4",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Outline" }
+						],
+						"visualizer": {
+							"type": "COLOR_PICKER"
+						},
+						"data": {
+							"x": 0,
+							"y": 0,
+							"z": 0,
+							"w": 1
+						},
+						"description": "Outline color. Only drawn when Stroke Width is greater than 0."
+					},
+					{
+						"name": "StrokeWidth",
+						"display_name": "Stroke Width",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Outline" }
+						],
+						"data": 0.0,
+						"min": 0.0,
+						"description": "Outline thickness in pixels. 0 disables the outline."
+					},
+					{
+						"name": "ShadowColor",
+						"display_name": "Shadow Color",
+						"type_name": "nos.fb.vec4",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Shadow" }
+						],
+						"visualizer": {
+							"type": "COLOR_PICKER"
+						},
+						"data": {
+							"x": 0,
+							"y": 0,
+							"z": 0,
+							"w": 0
+						},
+						"description": "Drop shadow color. Alpha 0 disables the shadow."
+					},
+					{
+						"name": "ShadowOffset",
+						"display_name": "Shadow Offset",
+						"type_name": "nos.fb.vec2",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Shadow" }
+						],
+						"data": {
+							"x": 3,
+							"y": 3
+						},
+						"description": "Drop shadow offset in pixels (x right, y down)."
+					},
+					{
+						"name": "ShadowSoftness",
+						"display_name": "Shadow Softness",
+						"type_name": "float",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Shadow" }
+						],
+						"data": 3.0,
+						"min": 0.0,
+						"description": "Drop shadow edge blur in pixels."
+					},
+					{
+						"name": "BackgroundColor",
+						"display_name": "Background Color",
+						"type_name": "nos.fb.vec4",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Background" }
+						],
+						"visualizer": {
+							"type": "COLOR_PICKER"
+						},
+						"data": {
+							"x": 0,
+							"y": 0,
+							"z": 0,
+							"w": 0.6
+						},
+						"description": "Color of the box drawn behind the text block.\nAlpha 0 disables the box; the frame stays transparent."
+					},
+					{
+						"name": "BackgroundPadding",
+						"display_name": "Background Padding",
+						"type_name": "nos.fb.vec2",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Background" }
+						],
+						"data": {
+							"x": 20,
+							"y": 10
+						},
+						"description": "Padding in pixels between the text and the background box edges."
+					},
+					{
+						"name": "HorizontalAlign",
+						"display_name": "Horizontal Align",
+						"type_name": "nos.utilities.TextHAlign",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_OUTPUT_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Layout" }
+						],
+						"data": "CENTER",
+						"description": "Horizontal anchor of the text block within the output."
+					},
+					{
+						"name": "VerticalAlign",
+						"display_name": "Vertical Align",
+						"type_name": "nos.utilities.TextVAlign",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_OUTPUT_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Layout" }
+						],
+						"data": "BOTTOM",
+						"description": "Vertical anchor of the text block within the output."
+					},
+					{
+						"name": "Position",
+						"type_name": "nos.fb.vec2",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Layout" }
+						],
+						"data": {
+							"x": 0,
+							"y": -50
+						},
+						"description": "Extra offset in pixels applied on top of the alignment anchor."
+					},
+					{
+						"name": "Resolution",
+						"type_name": "nos.fb.vec2u",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_OUTPUT_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Layout" }
+						],
+						"data": {
+							"x": 1920,
+							"y": 1080
+						},
+						"description": "Output texture resolution.",
+						"visualizer": {
+							"type": "NAMED_VALUE",
+							"name": "nos.mediaio.ResolutionVisualizer"
+						}
+					},
+					{
+						"name": "WrapWidth",
+						"display_name": "Wrap Width",
+						"type_name": "uint",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_OUTPUT_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Layout" }
+						],
+						"data": 0,
+						"description": "Word-wrap width in characters.\n0 wraps to the output texture width."
+					},
+					{
+						"name": "Font",
+						"type_name": "string",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_OUTPUT_PROPERTY",
+						"meta_data_map": [
+							{ "key": "Category", "value": "Font" }
+						],
+						"data": "",
+						"description": "Path to a .ttf/.otf font file.\nLeave empty to use the bundled Roboto Mono font.",
+						"visualizer": {
+							"type": "FILE_PICKER",
+							"file_extensions": [ "ttf", "otf" ],
+							"file_picker_type": "OPEN"
+						}
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY",
+						"data": {
+							"unscaled": true
+						}
+					}
+				]
+			}
+		}
+	]
+}

--- a/Plugins/nosUtilities/Shaders/TextBox.frag
+++ b/Plugins/nosUtilities/Shaders/TextBox.frag
@@ -1,0 +1,19 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(binding = 0, std430) uniform UBO
+{
+    vec2 Offset;
+    vec2 Size;
+    vec4 BoxColor;
+} ubo;
+
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 rt;
+
+void main()
+{
+    rt = ubo.BoxColor;
+}

--- a/Plugins/nosUtilities/Shaders/TextBox.vert
+++ b/Plugins/nosUtilities/Shaders/TextBox.vert
@@ -1,0 +1,29 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(location = 0) out vec2 uv;
+
+layout(binding = 0, std430) uniform UBO
+{
+    vec2 Offset;   // box top-left in 0..1 output coords (y down)
+    vec2 Size;     // box size in 0..1 output coords
+    vec4 BoxColor;
+} ubo;
+
+const vec2 pos[6] =
+    vec2[6](
+        vec2(0.0, +1.0),
+        vec2(+1.0, +1.0),
+        vec2(0.0, 0.0),
+        vec2(0.0, 0.0),
+        vec2(+1.0, +1.0),
+        vec2(+1.0, 0.0));
+
+void main()
+{
+    vec2 p = pos[gl_VertexIndex];
+    gl_Position = vec4((p * ubo.Size * 2) + vec2(-1, -1) + ubo.Offset * 2, 0.0, 1.0);
+    uv = p;
+}

--- a/Plugins/nosUtilities/Shaders/TextGlyph.frag
+++ b/Plugins/nosUtilities/Shaders/TextGlyph.frag
@@ -1,0 +1,42 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(binding = 1) uniform sampler2D Atlas;
+
+layout(binding = 0, std430) uniform UBO
+{
+    vec2 Offset;
+    vec2 Size;
+    vec4 AtlasRect;   // xy = atlas uv min, zw = atlas uv extent
+    vec4 FillColor;
+    vec4 StrokeColor;
+    float StrokeWidth; // outline thickness in output pixels (0 = none)
+    float Softness;    // extra edge blur in output pixels (drop shadow)
+    float PxRange;     // output pixels spanned by one full signed-distance unit
+} ubo;
+
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 rt;
+
+void main()
+{
+    // uv (0,0) is the glyph top-left, matching the top-down atlas bitmaps.
+    vec2 atlasUv = ubo.AtlasRect.xy + uv * ubo.AtlasRect.zw;
+    float sd = texture(Atlas, atlasUv).r; // signed distance, 0.5 = glyph edge
+
+    float distPx = (sd - 0.5) * ubo.PxRange; // signed distance, output pixels
+    float aa = 0.75 + ubo.Softness;
+
+    float fillA = smoothstep(-aa, aa, distPx);
+    float outerA = smoothstep(-aa, aa, distPx + ubo.StrokeWidth);
+
+    // Composite the fill over the stroke (stroke spans the whole silhouette).
+    float fa = ubo.FillColor.a * fillA;
+    float sa = ubo.StrokeColor.a * outerA;
+    float outA = fa + sa * (1.0 - fa);
+    vec3 outRGB = (ubo.FillColor.rgb * fa + ubo.StrokeColor.rgb * sa * (1.0 - fa)) / max(outA, 1e-5);
+
+    rt = vec4(outRGB, outA);
+}

--- a/Plugins/nosUtilities/Shaders/TextGlyph.vert
+++ b/Plugins/nosUtilities/Shaders/TextGlyph.vert
@@ -1,0 +1,34 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#extension GL_EXT_scalar_block_layout : enable
+
+layout(location = 0) out vec2 uv;
+
+layout(binding = 0, std430) uniform UBO
+{
+    vec2 Offset;     // glyph quad top-left in 0..1 output coords (y down)
+    vec2 Size;       // glyph quad size in 0..1 output coords
+    vec4 AtlasRect;  // xy = atlas uv min, zw = atlas uv extent
+    vec4 FillColor;
+    vec4 StrokeColor;
+    float StrokeWidth;
+    float Softness;
+    float PxRange;
+} ubo;
+
+const vec2 pos[6] =
+    vec2[6](
+        vec2(0.0, +1.0),
+        vec2(+1.0, +1.0),
+        vec2(0.0, 0.0),
+        vec2(0.0, 0.0),
+        vec2(+1.0, +1.0),
+        vec2(+1.0, 0.0));
+
+void main()
+{
+    vec2 p = pos[gl_VertexIndex];
+    gl_Position = vec4((p * ubo.Size * 2) + vec2(-1, -1) + ubo.Offset * 2, 0.0, 1.0);
+    uv = p;
+}

--- a/Plugins/nosUtilities/Source/Counter.cpp
+++ b/Plugins/nosUtilities/Source/Counter.cpp
@@ -1,0 +1,48 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+namespace nos::utilities
+{
+NOS_REGISTER_NAME(Step);
+NOS_REGISTER_NAME(Count);
+
+// Emits a running count that advances by Step on every execution. Drive it through
+// the In/Out exe pins so it can be scheduled, and call Reset to zero the count.
+struct CounterNode : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	uint64_t Counter = 0;
+
+	void SetCount(uint64_t value)
+	{
+		Counter = value;
+		SetPinValue(NSN_Count, Counter);
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& execParams) override
+	{
+		int32_t step = *execParams.GetPinValue<int32_t>(NSN_Step);
+		SetCount(Counter + step);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	nosResult Reset(nosFunctionExecuteParams*)
+	{
+		SetCount(0);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	NOS_DECLARE_FUNCTIONS(
+		NOS_ADD_FUNCTION(NOS_NAME("Reset"), Reset),
+	);
+};
+
+nosResult RegisterCounter(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME("Counter"), CounterNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::utilities

--- a/Plugins/nosUtilities/Source/TextRender.cpp
+++ b/Plugins/nosUtilities/Source/TextRender.cpp
@@ -1,0 +1,707 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosSysVulkan/Helpers.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_MODULE_H
+
+namespace nos::utilities
+{
+namespace fs = std::filesystem;
+
+NOS_REGISTER_NAME(TextRender)
+NOS_REGISTER_NAME(TextGlyph_Pass)
+NOS_REGISTER_NAME(TextGlyph_Frag)
+NOS_REGISTER_NAME(TextGlyph_Vert)
+NOS_REGISTER_NAME(TextBox_Pass)
+NOS_REGISTER_NAME(TextBox_Frag)
+NOS_REGISTER_NAME(TextBox_Vert)
+
+NOS_REGISTER_NAME(Text)
+NOS_REGISTER_NAME(FontSize)
+NOS_REGISTER_NAME(Color)
+NOS_REGISTER_NAME(Opacity)
+NOS_REGISTER_NAME(StrokeColor)
+NOS_REGISTER_NAME(StrokeWidth)
+NOS_REGISTER_NAME(ShadowColor)
+NOS_REGISTER_NAME(ShadowOffset)
+NOS_REGISTER_NAME(ShadowSoftness)
+NOS_REGISTER_NAME(BackgroundColor)
+NOS_REGISTER_NAME(BackgroundPadding)
+NOS_REGISTER_NAME(HorizontalAlign)
+NOS_REGISTER_NAME(VerticalAlign)
+NOS_REGISTER_NAME(Position)
+NOS_REGISTER_NAME(Resolution)
+NOS_REGISTER_NAME(WrapWidth)
+NOS_REGISTER_NAME(Font)
+NOS_REGISTER_NAME(Output)
+
+NOS_REGISTER_NAME(Offset)
+NOS_REGISTER_NAME(Size)
+NOS_REGISTER_NAME(AtlasRect)
+NOS_REGISTER_NAME(FillColor)
+NOS_REGISTER_NAME(Softness)
+NOS_REGISTER_NAME(PxRange)
+NOS_REGISTER_NAME(Atlas)
+NOS_REGISTER_NAME(BoxColor)
+
+// ASCII printable range packed into the SDF atlas.
+constexpr uint32_t FIRST_CHAR = 32;
+constexpr uint32_t LAST_CHAR = 126;
+constexpr uint32_t GLYPH_COUNT = LAST_CHAR - FIRST_CHAR + 1;
+// Reference size the atlas is rasterized at; the SDF is scaled by the shader.
+constexpr float REF_PIXEL_SIZE = 72.0f;
+// SDF spread in reference pixels: how far signed-distance data extends from the
+// glyph edge. Caps the usable outline thickness and shadow softness.
+constexpr int SDF_SPREAD = 16;
+constexpr int ATLAS_WIDTH = 1024;
+constexpr int ATLAS_PADDING = 2;
+// Upper bound on draw calls per execution to keep pathological inputs cheap.
+constexpr size_t MAX_DRAWN_GLYPHS = 8192;
+
+struct Glyph
+{
+	int AtlasX = 0, AtlasY = 0; // top-left in atlas pixels
+	int Width = 0, Height = 0;  // bitmap size in reference pixels
+	float BearingLeft = 0;      // pen-origin to bitmap left, reference pixels
+	float BearingTop = 0;       // baseline to bitmap top, reference pixels
+	float Advance = 0;          // horizontal advance, reference pixels
+	bool HasBitmap = false;
+};
+
+struct TextRenderNode : NodeContext
+{
+	FT_Library Library = nullptr;
+	// Node-owned GPU texture holding the SDF atlas. The ObjectRef owns the
+	// resource and frees it on reset/destruction; no manual DestroyResource.
+	nos::ObjectRef AtlasTex{};
+
+	std::array<Glyph, GLYPH_COUNT> Glyphs{};
+	int AtlasW = 0, AtlasH = 0;
+	float RefLineHeight = REF_PIXEL_SIZE * 1.2f;
+	float RefAscender = REF_PIXEL_SIZE;
+
+	// Path the current atlas was built from; empty means "bundled font".
+	std::optional<std::string> BuiltFontPath;
+	bool AtlasValid = false;
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		if (FT_Init_FreeType(&Library))
+		{
+			Library = nullptr;
+			nosEngine.LogE("TextRender: failed to initialize FreeType");
+			return NOS_RESULT_FAILED;
+		}
+		FT_Int spread = SDF_SPREAD;
+		FT_Property_Set(Library, "sdf", "spread", &spread);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	~TextRenderNode() override
+	{
+		DestroyAtlas();
+		if (Library)
+			FT_Done_FreeType(Library);
+	}
+
+	void DestroyAtlas()
+	{
+		AtlasTex = {};
+		AtlasValid = false;
+	}
+
+	std::string ResolveFontPath(const char* fontPin) const
+	{
+		if (fontPin && fontPin[0] != '\0')
+			return fontPin;
+		fs::path root = nosEngine.Plugin->RootFolderPath;
+		return (root / "Fonts" / "RobotoMono-Regular.ttf").generic_string();
+	}
+
+	// Rasterizes the printable ASCII range into a single-channel SDF atlas
+	// and uploads it as a texture. Returns false on failure.
+	bool BuildAtlas(const std::string& fontPath)
+	{
+		if (!Library)
+			return false;
+
+		FT_Face face = nullptr;
+		if (FT_New_Face(Library, fontPath.c_str(), 0, &face))
+		{
+			nosEngine.LogE("TextRender: could not open font '%s'", fontPath.c_str());
+			return false;
+		}
+		FT_Set_Pixel_Sizes(face, 0, static_cast<FT_UInt>(REF_PIXEL_SIZE));
+
+		RefLineHeight = (face->size->metrics.height >> 6) > 0 ? float(face->size->metrics.height >> 6)
+															  : REF_PIXEL_SIZE * 1.2f;
+		RefAscender = (face->size->metrics.ascender >> 6) > 0 ? float(face->size->metrics.ascender >> 6)
+															  : REF_PIXEL_SIZE;
+
+		struct Raster
+		{
+			std::vector<uint8_t> Pixels;
+			int W = 0, H = 0;
+		};
+		std::array<Raster, GLYPH_COUNT> rasters{};
+		std::array<Glyph, GLYPH_COUNT> glyphs{};
+
+		for (uint32_t i = 0; i < GLYPH_COUNT; ++i)
+		{
+			Glyph& g = glyphs[i];
+			if (FT_Load_Char(face, FIRST_CHAR + i, FT_LOAD_DEFAULT))
+				continue;
+			FT_GlyphSlot slot = face->glyph;
+			g.Advance = float(slot->advance.x >> 6);
+
+			if (FT_Render_Glyph(slot, FT_RENDER_MODE_SDF))
+				continue; // whitespace / empty outline: advance is still valid
+
+			const FT_Bitmap& bm = slot->bitmap;
+			if (bm.width == 0 || bm.rows == 0)
+				continue;
+
+			g.Width = int(bm.width);
+			g.Height = int(bm.rows);
+			g.BearingLeft = float(slot->bitmap_left);
+			g.BearingTop = float(slot->bitmap_top);
+			g.HasBitmap = true;
+
+			Raster& r = rasters[i];
+			r.W = int(bm.width);
+			r.H = int(bm.rows);
+			r.Pixels.resize(size_t(r.W) * r.H);
+			const int pitch = bm.pitch;
+			for (int row = 0; row < r.H; ++row)
+			{
+				const uint8_t* src = bm.buffer + size_t(row) * (pitch < 0 ? -pitch : pitch);
+				std::memcpy(r.Pixels.data() + size_t(row) * r.W, src, r.W);
+			}
+		}
+		FT_Done_Face(face);
+
+		// Shelf-pack the glyph bitmaps into a fixed-width atlas.
+		int x = ATLAS_PADDING, y = ATLAS_PADDING, shelfH = 0;
+		for (uint32_t i = 0; i < GLYPH_COUNT; ++i)
+		{
+			Glyph& g = glyphs[i];
+			if (!g.HasBitmap)
+				continue;
+			if (x + g.Width + ATLAS_PADDING > ATLAS_WIDTH)
+			{
+				x = ATLAS_PADDING;
+				y += shelfH + ATLAS_PADDING;
+				shelfH = 0;
+			}
+			g.AtlasX = x;
+			g.AtlasY = y;
+			x += g.Width + ATLAS_PADDING;
+			shelfH = std::max(shelfH, g.Height);
+		}
+		const int atlasW = ATLAS_WIDTH;
+		const int atlasH = y + shelfH + ATLAS_PADDING;
+
+		std::vector<uint8_t> pixels(size_t(atlasW) * atlasH, 0);
+		for (uint32_t i = 0; i < GLYPH_COUNT; ++i)
+		{
+			const Glyph& g = glyphs[i];
+			const Raster& r = rasters[i];
+			if (!g.HasBitmap)
+				continue;
+			for (int row = 0; row < r.H; ++row)
+				std::memcpy(pixels.data() + size_t(g.AtlasY + row) * atlasW + g.AtlasX,
+							r.Pixels.data() + size_t(row) * r.W,
+							r.W);
+		}
+
+		DestroyAtlas();
+
+		nosResourceInfo atlasInfo{};
+		atlasInfo.Type = NOS_RESOURCE_TYPE_TEXTURE;
+		atlasInfo.Texture = {.Width = uint32_t(atlasW),
+							 .Height = uint32_t(atlasH),
+							 .Format = NOS_FORMAT_R8_UNORM,
+							 .Usage = nosImageUsage(NOS_IMAGE_USAGE_SAMPLED | NOS_IMAGE_USAGE_TRANSFER_DST)};
+		nos::ObjectRef atlas{};
+		if (nosVulkan->CreateResource(&atlasInfo, 0, "TextRender Atlas", &atlas.GetStorage()) != NOS_RESULT_SUCCESS ||
+			!atlas)
+		{
+			nosEngine.LogE("TextRender: failed to create font atlas texture");
+			return false;
+		}
+
+		auto cmd = nos::sys::vulkan::BeginCmd(NOS_NAME("TextRenderAtlasUpload"), NodeId);
+		nosResult res = nosVulkan->ImageLoad(cmd,
+											 pixels.data(),
+											 nosVec2u{uint32_t(atlasW), uint32_t(atlasH)},
+											 NOS_FORMAT_R8_UNORM,
+											 atlas,
+											 NOS_TEXTURE_FILTER_LINEAR);
+		nos::sys::vulkan::EndCmd(cmd, NOS_TRUE);
+		if (res != NOS_RESULT_SUCCESS)
+		{
+			nosEngine.LogE("TextRender: failed to upload font atlas");
+			return false;
+		}
+
+		AtlasTex = std::move(atlas);
+		AtlasW = atlasW;
+		AtlasH = atlasH;
+		Glyphs = glyphs;
+		AtlasValid = true;
+		return true;
+	}
+
+	void EnsureAtlas(const char* fontPin)
+	{
+		std::string path = ResolveFontPath(fontPin);
+		if (AtlasValid && BuiltFontPath && *BuiltFontPath == path)
+			return;
+		BuiltFontPath = path;
+		if (BuildAtlas(path))
+			ClearNodeStatusMessages();
+		else
+			SetNodeStatusMessage("Could not load font.", fb::NodeStatusMessageType::FAILURE);
+	}
+
+	const Glyph* GlyphFor(char c) const
+	{
+		auto u = uint32_t(uint8_t(c));
+		if (u < FIRST_CHAR || u > LAST_CHAR)
+			return nullptr;
+		return &Glyphs[u - FIRST_CHAR];
+	}
+
+	// One laid-out glyph: index into Glyphs plus its pen origin on the line.
+	struct Placed
+	{
+		uint32_t GlyphIndex;
+		float PenX;
+		int Line;
+	};
+
+	// Greedy word-wrap layout in output-pixel space. Honors '\n' and breaks
+	// words longer than maxWidth character by character.
+	void LayoutText(const char* text,
+					float scale,
+					float maxWidth,
+					std::vector<Placed>& out,
+					std::vector<float>& lineWidths) const
+	{
+		const float spaceAdvance = [&] {
+			const Glyph* sp = GlyphFor(' ');
+			return sp ? sp->Advance * scale : REF_PIXEL_SIZE * 0.3f * scale;
+		}();
+
+		int line = 0;
+		float penX = 0.0f;
+		lineWidths.push_back(0.0f);
+
+		auto newLine = [&] {
+			lineWidths[line] = penX;
+			++line;
+			penX = 0.0f;
+			lineWidths.push_back(0.0f);
+		};
+		auto placeChar = [&](char c) {
+			const Glyph* g = GlyphFor(c);
+			if (!g)
+				return;
+			auto idx = uint32_t(uint8_t(c)) - FIRST_CHAR;
+			if (g->HasBitmap && out.size() < MAX_DRAWN_GLYPHS)
+				out.push_back({idx, penX, line});
+			penX += g->Advance * scale;
+		};
+
+		std::string word;
+		auto wordWidth = [&](const std::string& w) {
+			float width = 0.0f;
+			for (char c : w)
+				if (const Glyph* g = GlyphFor(c))
+					width += g->Advance * scale;
+			return width;
+		};
+		auto flushWord = [&] {
+			if (word.empty())
+				return;
+			float ww = wordWidth(word);
+			if (ww > maxWidth)
+			{
+				// Word does not fit on any line: hard-break per character.
+				for (char c : word)
+				{
+					const Glyph* g = GlyphFor(c);
+					float adv = g ? g->Advance * scale : 0.0f;
+					if (penX > 0.0f && penX + adv > maxWidth)
+						newLine();
+					placeChar(c);
+				}
+			}
+			else
+			{
+				if (penX > 0.0f && penX + ww > maxWidth)
+					newLine();
+				for (char c : word)
+					placeChar(c);
+			}
+			word.clear();
+		};
+
+		for (const char* p = text; *p; ++p)
+		{
+			char c = *p;
+			if (c == '\n')
+			{
+				flushWord();
+				newLine();
+			}
+			else if (c == ' ' || c == '\t')
+			{
+				flushWord();
+				float adv = (c == '\t') ? spaceAdvance * 4.0f : spaceAdvance;
+				if (penX > 0.0f)
+					penX += adv;
+			}
+			else
+			{
+				word.push_back(c);
+			}
+		}
+		flushWord();
+		lineWidths[line] = penX;
+	}
+
+	// Draws a flat-colored rectangle (the text-box background).
+	void DrawBox(nosCmd cmd,
+				 nosTextureObject tex,
+				 float outW,
+				 float outH,
+				 float x,
+				 float y,
+				 float w,
+				 float h,
+				 nosVec4 boxColor)
+	{
+		nosVec2 offset{x / outW, y / outH};
+		nosVec2 size{w / outW, h / outH};
+		std::array bindings = {nos::sys::vulkan::ShaderDataBinding(NSN_Offset, offset),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_Size, size),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_BoxColor, boxColor)};
+		nosVertexData vertexData{
+			.DepthFunc = NOS_DEPTH_FUNCTION_ALWAYS,
+			.DepthWrite = NOS_FALSE,
+			.DepthTest = NOS_FALSE,
+		};
+		nosRunPassParams pass{.Key = NSN_TextBox_Pass,
+							  .Bindings = bindings.data(),
+							  .BindingCount = uint32_t(bindings.size()),
+							  .Output = tex,
+							  .Vertices = vertexData,
+							  .Wireframe = NOS_FALSE,
+							  .Benchmark = NOS_FALSE,
+							  .DoNotClear = NOS_TRUE};
+		nosVulkan->RunPass(cmd, &pass);
+	}
+
+	// Draws one glyph quad. Used for both the shadow and the fill/stroke pass:
+	// the shadow passes the shadow color as the fill with a softened edge.
+	void DrawGlyph(nosCmd cmd,
+				   nosTextureObject tex,
+				   float outW,
+				   float outH,
+				   float glyphLeft,
+				   float glyphTop,
+				   float glyphW,
+				   float glyphH,
+				   nosVec4 atlasRect,
+				   nosVec4 fillColor,
+				   nosVec4 strokeColor,
+				   float strokeWidth,
+				   float softness,
+				   float pxRange)
+	{
+		nosVec2 offset{glyphLeft / outW, glyphTop / outH};
+		nosVec2 size{glyphW / outW, glyphH / outH};
+		std::array bindings = {nos::sys::vulkan::ShaderDataBinding(NSN_Offset, offset),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_Size, size),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_AtlasRect, atlasRect),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_FillColor, fillColor),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_StrokeColor, strokeColor),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_StrokeWidth, strokeWidth),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_Softness, softness),
+							   nos::sys::vulkan::ShaderDataBinding(NSN_PxRange, pxRange),
+							   nos::sys::vulkan::ShaderTextureBinding(NSN_Atlas, AtlasTex, NOS_TEXTURE_FILTER_LINEAR)};
+		nosVertexData vertexData{
+			.DepthFunc = NOS_DEPTH_FUNCTION_ALWAYS,
+			.DepthWrite = NOS_FALSE,
+			.DepthTest = NOS_FALSE,
+		};
+		nosRunPassParams pass{.Key = NSN_TextGlyph_Pass,
+							  .Bindings = bindings.data(),
+							  .BindingCount = uint32_t(bindings.size()),
+							  .Output = tex,
+							  .Vertices = vertexData,
+							  .Wireframe = NOS_FALSE,
+							  .Benchmark = NOS_FALSE,
+							  .DoNotClear = NOS_TRUE};
+		nosVulkan->RunPass(cmd, &pass);
+	}
+
+	nosResult ExecuteNode(nos::NodeExecuteParams const& args) override
+	{
+		const char* fontPin = args.GetPinValue<const char>(NSN_Font);
+		EnsureAtlas(fontPin);
+
+		auto resolution = *args.GetPinValue<nosVec2u>(NSN_Resolution);
+		if (resolution.x == 0 || resolution.y == 0)
+			return NOS_RESULT_SUCCESS;
+
+		// Resize the engine-managed output texture to match the requested resolution.
+		auto tex = args.GetPinObject<nos::sys::vulkan::Texture>(NSN_Output);
+		auto texInfo = nos::sys::vulkan::GetResourceInfo(tex);
+		if (!texInfo || texInfo->Width != resolution.x || texInfo->Height != resolution.y)
+		{
+			nosTextureInfo ti{.Width = resolution.x,
+							  .Height = resolution.y,
+							  .Format = NOS_FORMAT_R8G8B8A8_UNORM,
+							  .Usage = nosImageUsage(NOS_IMAGE_USAGE_SAMPLED | NOS_IMAGE_USAGE_RENDER_TARGET)};
+			tex = nos::sys::vulkan::CreateTexture(ti, "TextRender Output");
+			if (!tex)
+				return NOS_RESULT_FAILED;
+			SetPinObject(NSN_Output, tex);
+			texInfo = nos::sys::vulkan::GetResourceInfo(tex);
+			if (!texInfo)
+				return NOS_RESULT_SUCCESS;
+		}
+
+		const char* text = args.GetPinValue<const char>(NSN_Text);
+		float fontSize = *args.GetPinValue<float>(NSN_FontSize);
+		float opacity = std::clamp(*args.GetPinValue<float>(NSN_Opacity), 0.0f, 1.0f);
+		auto textColor = *args.GetPinValue<nosVec4>(NSN_Color);
+		auto strokeColor = *args.GetPinValue<nosVec4>(NSN_StrokeColor);
+		float strokeWidthPin = *args.GetPinValue<float>(NSN_StrokeWidth);
+		auto shadowColor = *args.GetPinValue<nosVec4>(NSN_ShadowColor);
+		auto shadowOffset = *args.GetPinValue<nosVec2>(NSN_ShadowOffset);
+		float shadowSoftnessPin = *args.GetPinValue<float>(NSN_ShadowSoftness);
+		auto boxColor = *args.GetPinValue<nosVec4>(NSN_BackgroundColor);
+		auto boxPadding = *args.GetPinValue<nosVec2>(NSN_BackgroundPadding);
+		auto hAlign = *args.GetPinValue<uint32_t>(NSN_HorizontalAlign);
+		auto vAlign = *args.GetPinValue<uint32_t>(NSN_VerticalAlign);
+		auto position = *args.GetPinValue<nosVec2>(NSN_Position);
+		auto wrapWidthChars = *args.GetPinValue<uint32_t>(NSN_WrapWidth);
+
+		// Global opacity folds into every color's alpha.
+		textColor.w *= opacity;
+		strokeColor.w *= opacity;
+		shadowColor.w *= opacity;
+		boxColor.w *= opacity;
+
+		// The frame outside the text box stays transparent.
+		auto cmd = nos::sys::vulkan::BeginCmd(NOS_NAME("TextRender"), NodeId);
+		nosVulkan->Clear(cmd, tex, nosVec4{0.0f, 0.0f, 0.0f, 0.0f});
+
+		if (AtlasValid && text && text[0] != '\0' && fontSize > 0.0f)
+		{
+			const float outW = float(texInfo->Width);
+			const float outH = float(texInfo->Height);
+			const float scale = fontSize / REF_PIXEL_SIZE;
+			const float lineHeight = RefLineHeight * scale;
+			const float ascender = RefAscender * scale;
+			const float pxRange = 2.0f * float(SDF_SPREAD) * scale;
+			// The SDF only carries data within SDF_SPREAD reference pixels of the
+			// glyph edge, which bounds outline thickness and shadow softness.
+			const float effectLimit = float(SDF_SPREAD) * scale;
+			const float strokeWidth = std::clamp(strokeWidthPin, 0.0f, effectLimit);
+			const float shadowSoftness = std::clamp(shadowSoftnessPin, 0.0f, effectLimit);
+
+			// WrapWidth is in characters; 0 falls back to the texture width.
+			// The character cell width is the font's space advance, which is
+			// exact for monospace fonts and approximate for proportional ones.
+			float wrapWidth = outW;
+			if (wrapWidthChars > 0)
+			{
+				const Glyph* space = GlyphFor(' ');
+				const float charWidth = (space ? space->Advance : REF_PIXEL_SIZE * 0.6f) * scale;
+				wrapWidth = float(wrapWidthChars) * charWidth;
+			}
+
+			std::vector<Placed> placed;
+			std::vector<float> lineWidths;
+			LayoutText(text, scale, wrapWidth, placed, lineWidths);
+
+			const uint32_t numLines = uint32_t(lineWidths.size());
+			const float blockHeight = lineHeight * float(numLines);
+
+			float vBase = 0.0f;
+			if (vAlign == 1) // MIDDLE
+				vBase = (outH - blockHeight) * 0.5f;
+			else if (vAlign == 2) // BOTTOM
+				vBase = outH - blockHeight;
+			const float vOffset = vBase + position.y;
+
+			// Per-line horizontal anchor offset (alignment + position nudge).
+			std::vector<float> hOffsets(numLines);
+			for (uint32_t i = 0; i < numLines; ++i)
+			{
+				float off = 0.0f;
+				if (hAlign == 1) // CENTER
+					off = (outW - lineWidths[i]) * 0.5f;
+				else if (hAlign == 2) // RIGHT
+					off = outW - lineWidths[i];
+				hOffsets[i] = off + position.x;
+			}
+
+			// Text-block bounds, used for the background box.
+			float blockLeft = outW, blockRight = 0.0f;
+			bool anyLine = false;
+			for (uint32_t i = 0; i < numLines; ++i)
+			{
+				if (lineWidths[i] <= 0.0f)
+					continue;
+				anyLine = true;
+				blockLeft = std::min(blockLeft, hOffsets[i]);
+				blockRight = std::max(blockRight, hOffsets[i] + lineWidths[i]);
+			}
+
+			// Background box, behind everything.
+			if (anyLine && boxColor.w > 0.0f)
+				DrawBox(cmd,
+						tex,
+						outW,
+						outH,
+						blockLeft - boxPadding.x,
+						vOffset - boxPadding.y,
+						(blockRight - blockLeft) + 2.0f * boxPadding.x,
+						blockHeight + 2.0f * boxPadding.y,
+						boxColor);
+
+			auto glyphRect = [&](const Placed& gp, float& left, float& top, float& w, float& h) {
+				const Glyph& g = Glyphs[gp.GlyphIndex];
+				const float baseline = vOffset + ascender + float(gp.Line) * lineHeight;
+				left = hOffsets[gp.Line] + gp.PenX + g.BearingLeft * scale;
+				top = baseline - g.BearingTop * scale;
+				w = float(g.Width) * scale;
+				h = float(g.Height) * scale;
+			};
+			auto atlasRectOf = [&](const Placed& gp) {
+				const Glyph& g = Glyphs[gp.GlyphIndex];
+				return nosVec4{float(g.AtlasX) / float(AtlasW),
+							   float(g.AtlasY) / float(AtlasH),
+							   float(g.Width) / float(AtlasW),
+							   float(g.Height) / float(AtlasH)};
+			};
+
+			// Drop shadow: all shadows first so no glyph fill is tinted by a
+			// neighbouring glyph's shadow.
+			if (shadowColor.w > 0.0f)
+			{
+				nosVec4 noStroke{0.0f, 0.0f, 0.0f, 0.0f};
+				for (const Placed& gp : placed)
+				{
+					float left, top, w, h;
+					glyphRect(gp, left, top, w, h);
+					DrawGlyph(cmd,
+							  tex,
+							  outW,
+							  outH,
+							  left + shadowOffset.x,
+							  top + shadowOffset.y,
+							  w,
+							  h,
+							  atlasRectOf(gp),
+							  shadowColor,
+							  noStroke,
+							  0.0f,
+							  shadowSoftness,
+							  pxRange);
+				}
+			}
+
+			// Fill + outline.
+			for (const Placed& gp : placed)
+			{
+				float left, top, w, h;
+				glyphRect(gp, left, top, w, h);
+				DrawGlyph(cmd,
+						  tex,
+						  outW,
+						  outH,
+						  left,
+						  top,
+						  w,
+						  h,
+						  atlasRectOf(gp),
+						  textColor,
+						  strokeColor,
+						  strokeWidth,
+						  0.0f,
+						  pxRange);
+			}
+		}
+
+		nos::sys::vulkan::EndCmd(cmd, NOS_FALSE);
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+static nosResult RegisterShaderPair(const fs::path& root,
+									const char* baseName,
+									nosName fragKey,
+									nosName vertKey)
+{
+	auto fragPath = (root / "Shaders" / (std::string(baseName) + ".frag")).generic_string();
+	auto vertPath = (root / "Shaders" / (std::string(baseName) + ".vert")).generic_string();
+	std::array shaders = {
+		nosShaderInfo{.ShaderName = fragKey,
+					  .Source = {.Stage = NOS_SHADER_STAGE_FRAG, .GLSLPath = fragPath.c_str()},
+					  .AssociatedNodeClassName = NSN_TextRender},
+		nosShaderInfo{.ShaderName = vertKey,
+					  .Source = {.Stage = NOS_SHADER_STAGE_VERT, .GLSLPath = vertPath.c_str()},
+					  .AssociatedNodeClassName = NSN_TextRender},
+	};
+	return nosVulkan->RegisterShaders(shaders.size(), shaders.data());
+}
+
+nosResult RegisterTextRender(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NSN_TextRender, TextRenderNode, fn);
+
+	fs::path root = nosEngine.Plugin->RootFolderPath;
+	if (nosResult ret = RegisterShaderPair(root, "TextGlyph", NSN_TextGlyph_Frag, NSN_TextGlyph_Vert);
+		ret != NOS_RESULT_SUCCESS)
+		return ret;
+	if (nosResult ret = RegisterShaderPair(root, "TextBox", NSN_TextBox_Frag, NSN_TextBox_Vert);
+		ret != NOS_RESULT_SUCCESS)
+		return ret;
+
+	std::array passes = {
+		nosPassInfo{
+			.Key = NSN_TextGlyph_Pass,
+			.Shader = NSN_TextGlyph_Frag,
+			.VertexShader = NSN_TextGlyph_Vert,
+			.MultiSample = 1,
+			.Blend = NOS_BLEND_MODE_ALPHA_BLENDING,
+		},
+		nosPassInfo{
+			.Key = NSN_TextBox_Pass,
+			.Shader = NSN_TextBox_Frag,
+			.VertexShader = NSN_TextBox_Vert,
+			.MultiSample = 1,
+			.Blend = NOS_BLEND_MODE_ALPHA_BLENDING,
+		},
+	};
+	return nosVulkan->RegisterPasses(passes.size(), passes.data());
+}
+
+} // namespace nos::utilities

--- a/Plugins/nosUtilities/Source/UtilitiesMain.cpp
+++ b/Plugins/nosUtilities/Source/UtilitiesMain.cpp
@@ -18,6 +18,8 @@ enum class Utilities : size_t
 	PrintLog,
 	Sink,
 	Time,
+	Counter,
+	TextRender,
 	Count,
 };
 
@@ -25,6 +27,8 @@ void RegisterHost(nosNodeFunctions*);
 void RegisterPrintLog(nosNodeFunctions*);
 void RegisterSink(nosNodeFunctions*);
 void RegisterTime(nosNodeFunctions*);
+nosResult RegisterCounter(nosNodeFunctions*);
+nosResult RegisterTextRender(nosNodeFunctions*);
 
 nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outSize, nosNodeFunctions** outList)
 {
@@ -37,6 +41,8 @@ nosResult NOSAPI_CALL ExportNodeFunctions(size_t* outSize, nosNodeFunctions** ou
 	RegisterPrintLog(outList[static_cast<size_t>(Utilities::PrintLog)]);
 	RegisterSink(outList[static_cast<size_t>(Utilities::Sink)]);
 	RegisterTime(outList[static_cast<size_t>(Utilities::Time)]);
+	RegisterCounter(outList[static_cast<size_t>(Utilities::Counter)]);
+	RegisterTextRender(outList[static_cast<size_t>(Utilities::TextRender)]);
 	return NOS_RESULT_SUCCESS;
 }
 

--- a/Plugins/nosUtilities/Types/TextRender.fbs
+++ b/Plugins/nosUtilities/Types/TextRender.fbs
@@ -1,0 +1,15 @@
+namespace nos.utilities;
+
+enum TextHAlign : uint
+{
+    LEFT   = 0,
+    CENTER = 1,
+    RIGHT  = 2,
+}
+
+enum TextVAlign : uint
+{
+    TOP    = 0,
+    MIDDLE = 1,
+    BOTTOM = 2,
+}

--- a/Tools/parity/gen_tests.py
+++ b/Tools/parity/gen_tests.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Generates parity test graphs (*.nosa) for ported nodes.
+# Each test: Thread -> TestScheduler drives the graph; the node-under-test's output
+# is fed into nos.reflect.IsEqual(expected); IsEqual -> nos.test.Assert with
+# EXIT_WITH_STATUS_CODE so `nodos test` gets a pass/fail exit code.
+#
+# Usage:  python gen_tests.py spec.json
+# Writes  Plugins/<plugin>/Tests/<TestName>_Parity.nosa  for each spec entry.
+import json, os, sys, uuid, copy
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PLUGINS = os.path.abspath(os.path.join(HERE, "..", ".."))  # Module/plugins
+
+def nid():
+    return str(uuid.uuid4())
+
+def pin(name, type_name, show_as, data, extra=None):
+    p = {
+        "id": nid(), "name": name, "type_name": type_name,
+        "show_as": show_as,
+        "can_show_as": "OUTPUT_PIN_ONLY" if show_as == "OUTPUT_PIN" else "INPUT_PIN_OR_PROPERTY",
+        "visualizers": [], "data": data, "def": data,
+        "contents_type": "JobPin", "contents": {}, "orphan_state": {},
+    }
+    if extra:
+        p.update(extra)
+    return p
+
+def job(name, class_name, pins, x, y, always=False, plugin_ver=(0, 0, 0)):
+    n = {
+        "id": nid(), "name": name, "class_name": class_name, "pins": pins,
+        "pos": {"x": x, "y": y}, "contents_type": "Job", "contents": {"type": ""},
+        "function_category": "Default Node",
+        "plugin_version": {"major": plugin_ver[0], "minor": plugin_ver[1], "patch": plugin_ver[2]},
+    }
+    if always:
+        n["always_execute"] = True
+    return n
+
+def plugin_id(plugin):
+    import glob
+    for mf in glob.glob(os.path.join(PLUGINS, "Plugins", plugin, "*.nosplugin")):
+        return json.load(open(mf, encoding="utf-8"))["info"]["id"]["name"]
+    raise SystemExit("no .nosplugin in " + plugin)
+
+def plugin_name_ver(plugin):
+    import glob
+    for mf in glob.glob(os.path.join(PLUGINS, "Plugins", plugin, "*.nosplugin")):
+        i = json.load(open(mf, encoding="utf-8"))["info"]["id"]
+        return {"name": i["name"], "version": i["version"]}
+    raise SystemExit("no .nosplugin in " + plugin)
+
+def loaded_modules_for(plugin):
+    # The graph needs the test harness (nos.test), IsEqual (nos.reflect), and the
+    # plugin under test loaded as modules so their fbs types (e.g.
+    # nos.test.AssertionBehaviour) resolve — required for the Assert exit to fire.
+    mods = [{"name": "nos.test", "version": "0.3.1"},
+            {"name": "nos.reflect", "version": "3.0.0"}]
+    tgt = plugin_name_ver(plugin)
+    if tgt["name"] not in [m["name"] for m in mods]:
+        mods.append(tgt)
+    return mods
+
+def fqn(plugin, class_name):
+    return class_name if "." in class_name else plugin_id(plugin) + "." + class_name
+
+def load_node_template(plugin, nosnode, class_name):
+    path = os.path.join(PLUGINS, "Plugins", plugin, "Nodes", nosnode + ".nosnode")
+    doc = json.load(open(path, encoding="utf-8"))
+    for entry in doc["nodes"]:
+        node = entry.get("node", entry)
+        if node.get("class_name") == class_name:
+            return copy.deepcopy(node)
+    raise SystemExit("class %s not found in %s" % (class_name, path))
+
+def instantiate(plugin, nosnode, class_name, inputs, x, y):
+    tmpl = load_node_template(plugin, nosnode, class_name)
+    tmpl_pins = tmpl.get("pins", [])
+    out_pins = {}
+    pins = []
+    for tp in tmpl_pins:
+        np = {
+            "id": nid(), "name": tp["name"], "type_name": tp["type_name"],
+            "show_as": tp.get("show_as", "INPUT_PIN"),
+            "can_show_as": tp.get("can_show_as", "INPUT_PIN_OR_PROPERTY"),
+            "visualizers": [], "contents_type": "JobPin", "contents": {}, "orphan_state": {},
+        }
+        if tp["name"] in inputs:
+            np["data"] = inputs[tp["name"]]
+        elif "data" in tp:
+            np["data"] = tp["data"]
+        if "data" in np:
+            np["def"] = np["data"]
+        pins.append(np)
+        if np["show_as"] == "OUTPUT_PIN":
+            out_pins[tp["name"]] = np
+    node = job(class_name.split(".")[-1], fqn(plugin, class_name), pins, x, y)
+    return node, out_pins
+
+def build_graph(case):
+    conns = []
+    # Thread (driver)
+    th_run = pin("Run", "nos.exe", "OUTPUT_PIN", {})
+    th_run["live"] = True
+    thread = job("Thread", "nos.Thread",
+                 [th_run, pin("Importance", "ulong", "PROPERTY", 0,
+                              {"can_show_as": "PROPERTY_ONLY"})],
+                 86, -94, always=True)
+    # TestScheduler
+    ts_run = pin("Run", "nos.exe", "INPUT_PIN", {}, {"can_show_as": "INPUT_PIN_ONLY"})
+    ts_sink = pin("Sink", "uint", "INPUT_PIN", 1, {"can_show_as": "INPUT_PIN_ONLY"})
+    scheduler = job("TestScheduler", "nos.test.TestScheduler",
+                    [ts_run, ts_sink,
+                     pin("FreeRun", "bool", "PROPERTY", False),
+                     pin("DeltaTime", "nos.fb.vec2u", "PROPERTY", {"x": 1, "y": 60})],
+                    324, 7, plugin_ver=(0, 3, 1))
+    # node under test
+    node, outs = instantiate(case["plugin"], case["nosnode"], case["class"],
+                             case.get("inputs", {}), -266, 14)
+    out_pin = outs[case["output"]]
+    out_type = out_pin["type_name"]
+    # IsEqual (concrete output type, not Generic, to avoid type-resolution issues)
+    eq_a = pin("A", out_type, "INPUT_PIN", case["expected"])
+    eq_b = pin("B", out_type, "INPUT_PIN", case["expected"])
+    eq_out = pin("IsEqual", "bool", "OUTPUT_PIN", True)
+    iseq = job("IsEqual", "nos.reflect.IsEqual", [eq_a, eq_b, eq_out], -105, 4, plugin_ver=(3, 0, 0))
+    # Assert
+    as_beh = pin("Behaviour", "nos.test.AssertionBehaviour", "PROPERTY", "EXIT_WITH_STATUS_CODE")
+    as_wait = pin("NumFramesToWait", "uint", "PROPERTY", 0)
+    as_fc = pin("FrameCount", "uint", "OUTPUT_PIN", 1)
+    as_cond = pin("Condition", "bool", "INPUT_PIN", True)
+    as_over = pin("NumFramesToAssertOver", "uint", "PROPERTY", 1, {"min": 1})
+    assert_node = job("Assert", "nos.test.Assert",
+                      [as_beh, as_wait, as_fc, as_cond, as_over], 93, 11, plugin_ver=(0, 3, 1))
+    # connections
+    conns.append({"from": th_run["id"], "to": ts_run["id"], "id": nid()})
+    conns.append({"from": as_fc["id"], "to": ts_sink["id"], "id": nid()})
+    conns.append({"from": eq_out["id"], "to": as_cond["id"], "id": nid()})
+    conns.append({"from": out_pin["id"], "to": eq_a["id"], "id": nid()})
+    graph = {
+        "info": {"version": "1.4.0.b0", "loaded_modules": loaded_modules_for(case["plugin"])},
+        "graph": {
+            "id": nid(), "pos": {"x": 0, "y": 0}, "contents_type": "Graph",
+            "contents": {"nodes": [thread, scheduler, assert_node, iseq, node],
+                         "connections": conns},
+            "plugin_version": {"major": 0, "minor": 0, "patch": 0},
+        },
+    }
+    return graph
+
+def main():
+    spec = json.load(open(sys.argv[1], encoding="utf-8"))
+    for case in spec:
+        g = build_graph(case)
+        outdir = os.path.join(PLUGINS, "Plugins", case["plugin"], "Tests")
+        os.makedirs(outdir, exist_ok=True)
+        fn = os.path.join(outdir, case["name"] + "_Parity.nosa")
+        json.dump(g, open(fn, "w", encoding="utf-8"), indent=2)
+        print("wrote", os.path.relpath(fn, PLUGINS))
+
+if __name__ == "__main__":
+    main()

--- a/Tools/parity/spec.json
+++ b/Tools/parity/spec.json
@@ -1,0 +1,47 @@
+[
+  {
+    "plugin": "nosMath", "nosnode": "EulerToQuaternion", "class": "EulerToQuaternion",
+    "name": "EulerToQuaternion_Identity",
+    "inputs": { "Euler": { "x": 0.0, "y": 0.0, "z": 0.0 }, "Order": "ZYX" },
+    "output": "Quaternion", "expected": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 }
+  },
+  {
+    "plugin": "nosMath", "nosnode": "QuaternionMultiply", "class": "QuaternionMultiply",
+    "name": "QuaternionMultiply_Identity",
+    "inputs": { "A": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 }, "B": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 } },
+    "output": "Result", "expected": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 }
+  },
+  {
+    "plugin": "nosMath", "nosnode": "QuaternionToEuler", "class": "QuaternionToEuler",
+    "name": "QuaternionToEuler_Identity",
+    "inputs": { "Quaternion": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 }, "Order": "ZYX" },
+    "output": "Euler", "expected": { "x": 0.0, "y": 0.0, "z": 0.0 }
+  },
+  {
+    "plugin": "nosStrings", "nosnode": "StringFormat", "class": "StringFormat",
+    "name": "StringFormat_Literal",
+    "inputs": { "Format": "hello" },
+    "output": "Output", "expected": "hello"
+  },
+  {
+    "plugin": "nosTrack", "nosnode": "ConvertTransform", "class": "ConvertTransform",
+    "name": "ConvertTransform_SameFrameIsIdentity",
+    "inputs": {
+      "In": { "position": { "x": 1.0, "y": 2.0, "z": 3.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } },
+      "SourceFrame": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 },
+      "TargetFrame": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 }
+    },
+    "output": "Out",
+    "expected": { "position": { "x": 1.0, "y": 2.0, "z": 3.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } }
+  },
+  {
+    "plugin": "nosGraphics", "nosnode": "TrackToTransformQ", "class": "TrackToTransformQ",
+    "name": "TrackToTransformQ_Identity",
+    "inputs": {
+      "Track": { "location": { "x": 1.0, "y": 2.0, "z": 3.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 } },
+      "Frame": { "up": "PosZ", "forward": "PosX", "handedness": "LeftHanded", "euler": { "order": "ZYX", "sign_x": -1, "sign_y": -1, "sign_z": 1 }, "meters_per_unit": 0.01 }
+    },
+    "output": "Out",
+    "expected": { "position": { "x": 1.0, "y": 2.0, "z": 3.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } }
+  }
+]


### PR DESCRIPTION
Ports all node-adding work from `origin/nodos-1.3` onto `dev` (SDK 41 / 1.4 plugin structure): **32 nodes across 7 plugins**, two of them new (`nos.graphics`, `nos.geometry`).

## Plugins
| Plugin | Nodes |
|---|---|
| nosMath | EulerToQuaternion, QuaternionMultiply, QuaternionToEuler, Vec3ToVec4, EmbedMat3ToMat4 (+ Math.fbs EulerOrder) |
| nosStrings | StringFormat |
| nosFilters | BokehDof, BokehShape, DepthOfField, DirectionalDof |
| nosTrack | ConvertTrackFrame, ConvertTransform, ReOriginTrack, PlaybackTrackCOLMAP, RecordTrackCOLMAP, UpdateTrackTransform |
| nosUtilities | Counter, TextRender (+ FreeType submodule) |
| nosResource | MultiRingBuffer, MultiBoundedQueue |
| **nosGraphics (new)** | TrackToView, BillboardPositions, HomographySolver, ConvertCoordinateFrame, CameraGuide, TrackToTransformQ, NormalizedDepthToDepthBuffer, BillboardMask, + macro nodes |
| **nosGeometry (new)** | ReadFBXTransform (+ openFBX submodule) |

## Notes
- Structural conversion `.nosdef`→`.nosnode`, `Config/*.fbs`→`Types/`, `.noscfg/.nossys`→`.nosplugin`; SDK-41 source adaptations throughout.
- GPU nodes rewritten to vulkan-8 (ObjectRef / CreateTexture / ShaderDataBinding).
- Multi* queues migrated to dev's redesigned `ResourceInterface`.
- Coordinate types + `CoordinateFrameConversion` moved into `nos.track` so graphics/geometry → track stays one-way (acyclic).
- Adds `Tools/parity` (parity-test generator) + per-plugin `Tests/*.nosa`.
- Two new submodules: openFBX (nosGeometry), FreeType (nosUtilities).

## Drive-by fixes (pre-existing dev bugs found in review — drop if out of scope)
- nosTrack: Transform animation interpolator was never registered (copy-paste).
- nosStrings: node-class renames were assigned to `GetRenamedTypes`; moved to `GetRenamedNodeClasses`.

## Status / not yet verified
- ✅ Full `nodos dev build --config Release` green (32 targets).
- ✅ All nodes load with correct types (no orphans/missing classes); 265/265 1.3 node classes accounted for.
- ⚠️ **Runtime parity tests not yet run** — the bundled `nos.test` plugin's runtime fails to load against engine API 41.0, so test asserts can't fire. Needs a compatible `nos.test` build.
- ⚠️ The GPU nodes (TextRender atlas, BillboardMask, NormalizedDepth) and Multi* queue copy lifecycle warrant a manual/runtime check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)